### PR TITLE
Fix references to non-existent enchantment mcdw:chained (should be mcdw:chains)

### DIFF
--- a/src/main/java/chronosacaria/mcdw/configs/McdwEnchantsGiverConfig.java
+++ b/src/main/java/chronosacaria/mcdw/configs/McdwEnchantsGiverConfig.java
@@ -14,9 +14,9 @@ public class McdwEnchantsGiverConfig {
                 new Identifier("mcdw:bonus_shot"), 1, true);
         // CHAINS ENCHANTMENT
         EnchantsList.addEnchant(Registry.ITEM.getId(ItemRegistry.ITEMS.get("hammer_flail")),
-                new Identifier("mcdw:chained"), 1, true);
+                new Identifier("mcdw:chains"), 1, true);
         EnchantsList.addEnchant(Registry.ITEM.getId(ItemRegistry.ITEMS.get("sickle_jailors_scythe")),
-                new Identifier("mcdw:chained"), 1, true);
+                new Identifier("mcdw:chains"), 1, true);
 
         // CHAIN REACTION ENCHANTMENT
         EnchantsList.addEnchant(Registry.ITEM.getId(ItemRegistry.ITEMS.get("crossbow_firebolt_thrower")),

--- a/src/main/resources/assets/mcdw/lang/en_gb.json
+++ b/src/main/resources/assets/mcdw/lang/en_gb.json
@@ -155,7 +155,7 @@
   "enchantment.mcdw.anima_conduit": "Anima Conduit",
   "enchantment.mcdw.bonus_shot": "Bonus Shot",
   "enchantment.mcdw.chain_reaction": "Chain Reaction",
-  "enchantment.mcdw.chained": "Chains",
+  "enchantment.mcdw.chains": "Chains",
   "enchantment.mcdw.charge": "Charge",
   "enchantment.mcdw.committed": "Committed",
   "enchantment.mcdw.critical_hit": "Critical Hit",

--- a/src/main/resources/assets/mcdw/lang/es_es.json
+++ b/src/main/resources/assets/mcdw/lang/es_es.json
@@ -142,7 +142,7 @@
   "enchantment.mcdw.anima_conduit": "Anima Conduit",
   "enchantment.mcdw.bonus_shot": "Bonus Shot",
   "enchantment.mcdw.chain_reaction": "Chain Reaction",
-  "enchantment.mcdw.chained": "Chains",
+  "enchantment.mcdw.chains": "Chains",
   "enchantment.mcdw.charge": "Charge",
   "enchantment.mcdw.committed": "Committed",
   "enchantment.mcdw.critical_hit": "Critical Hit",

--- a/src/main/resources/assets/mcdw/lang/ko_kr.json
+++ b/src/main/resources/assets/mcdw/lang/ko_kr.json
@@ -155,7 +155,7 @@
   "enchantment.mcdw.anima_conduit": "정신 도관",
   "enchantment.mcdw.bonus_shot": "보너스 공격",
   "enchantment.mcdw.chain_reaction": "사슬 반응",
-  "enchantment.mcdw.chained": "사슬",
+  "enchantment.mcdw.chains": "사슬",
   "enchantment.mcdw.charge": "충전",
   "enchantment.mcdw.committed": "추가 사격",
   "enchantment.mcdw.critical_hit": "치명타",

--- a/src/main/resources/assets/mcdw/lang/pt_pt.json
+++ b/src/main/resources/assets/mcdw/lang/pt_pt.json
@@ -141,7 +141,7 @@
   "enchantment.mcdw.anima_conduit": "Anima Conduit",
   "enchantment.mcdw.bonus_shot": "Bonus Shot",
   "enchantment.mcdw.chain_reaction": "Chain Reaction",
-  "enchantment.mcdw.chained": "Chains",
+  "enchantment.mcdw.chains": "Chains",
   "enchantment.mcdw.charge": "Charge",
   "enchantment.mcdw.committed": "Committed",
   "enchantment.mcdw.critical_hit": "Critical Hit",

--- a/src/main/resources/assets/mcdw/lang/ru_ru.json
+++ b/src/main/resources/assets/mcdw/lang/ru_ru.json
@@ -142,7 +142,7 @@
   "enchantment.mcdw.anima_conduit": "Проводник Души",
   "enchantment.mcdw.bonus_shot": "Бонусный Выстрел",
   "enchantment.mcdw.chain_reaction": "Цепная Реакция",
-  "enchantment.mcdw.chained": "Цепи",
+  "enchantment.mcdw.chains": "Цепи",
   "enchantment.mcdw.charge": "Charge",
   "enchantment.mcdw.committed": "Целеустремлённость",
   "enchantment.mcdw.critical_hit": "Критический Удар",


### PR DESCRIPTION
The Hammer Flail and Jailor's Scythe now have the enchantment they're supposed to have and all the translations show up.