### PR TITLE
Fix some damage formulas

### DIFF
--- a/src/main/java/chronosacaria/mcdw/mixin/enchantments/BonusShotBowEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/enchantments/BonusShotBowEnchantmentMixin.java
@@ -25,7 +25,7 @@ public class BonusShotBowEnchantmentMixin {
         if (McdwEnchantsConfig.getValue("bonus_shot")){
             if (McdwEnchantmentHelper.hasEnchantment(stack, RangedEnchantmentList.BONUS_SHOT) || uniqueWeaponFlag){
                 int bonusShotLevel = EnchantmentHelper.getLevel(RangedEnchantmentList.BONUS_SHOT, stack);
-                float damageMultiplier = 0.1F + (bonusShotLevel - 1 * 0.07F);
+                float damageMultiplier = 0.1F + ((bonusShotLevel - 1) * 0.07F);
                 float arrowVelocity = RangedAttackHelper.getVanillaOrModdedBowArrowVelocity(stack, remainingUseTicks);
                 if (arrowVelocity >= 0.1F){
                     ProjectileEffectHelper.fireBonusShotTowardsOtherEntity(user, 10, damageMultiplier, arrowVelocity);

--- a/src/main/java/chronosacaria/mcdw/mixin/enchantments/BonusShotEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/enchantments/BonusShotEnchantmentMixin.java
@@ -38,8 +38,7 @@ public class BonusShotEnchantmentMixin {
                                     || stack.getItem() == ItemRegistry.getItem("crossbow_auto_crossbow").asItem();
                     if (McdwEnchantmentHelper.hasEnchantment(stack, RangedEnchantmentList.BONUS_SHOT) || uniqueWeaponFlag) {
                         int bonusShotLevel = EnchantmentHelper.getLevel(RangedEnchantmentList.BONUS_SHOT, stack);
-                        float damageMultiplier;
-                        damageMultiplier = 0.1F + (bonusShotLevel - 1 * 0.07F);
+                        float damageMultiplier = 0.1F + ((bonusShotLevel - 1) * 0.07F);
                         if (uniqueWeaponFlag) {
                             damageMultiplier += 0.1F;
                         }

--- a/src/main/java/chronosacaria/mcdw/mixin/enchantments/RicochetEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/enchantments/RicochetEnchantmentMixin.java
@@ -4,12 +4,11 @@ import chronosacaria.mcdw.api.util.ProjectileEffectHelper;
 import chronosacaria.mcdw.bases.McdwBow;
 import chronosacaria.mcdw.configs.McdwEnchantsConfig;
 import chronosacaria.mcdw.enchants.EnchantsRegistry;
-import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ItemStack;
+import net.minecraft.item.Item;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
@@ -22,23 +21,16 @@ public class RicochetEnchantmentMixin {
     public void applyRicochet(DamageSource source, float amount, CallbackInfo info) {
         if (!(source.getAttacker() instanceof PlayerEntity)) return;
 
-        PlayerEntity user = (PlayerEntity) source.getAttacker();
+        PlayerEntity attacker = (PlayerEntity) source.getAttacker();
         LivingEntity target = (LivingEntity) (Object) this;
-        ItemStack mainHandStack = null;
 
-        if (user != null) {
-            mainHandStack = user.getMainHandStack();
-        }
         if (McdwEnchantsConfig.getValue("ricochet"))  {
-
-            if (mainHandStack != null && (EnchantmentHelper.getLevel(EnchantsRegistry.RICOCHET, mainHandStack) >= 1)) {
-                int level = EnchantmentHelper.getLevel(EnchantsRegistry.RICOCHET, mainHandStack);
-                float damageMultiplier;
-                damageMultiplier = 0.1F + (level - 1 * 0.07F);
+            int level = EnchantmentHelper.getLevel(EnchantsRegistry.RICOCHET, attacker.getMainHandStack());
+            if (level >= 1) {
+                float damageMultiplier = 0.1F + ((level - 1) * 0.07F);
                 float arrowVelocity = McdwBow.maxBowRange;
                 if (arrowVelocity > 0.1F) {
-                    ProjectileEffectHelper.riochetArrowTowardsOtherEntity(target, 10, damageMultiplier,
-                            arrowVelocity);
+                    ProjectileEffectHelper.riochetArrowTowardsOtherEntity(target, 10, damageMultiplier, arrowVelocity);
                 }
             }
         }


### PR DESCRIPTION
Damage multipliers for some enchantments are way higher than intended (I'm assuming) because
`0.1F + (level - 1 * 0.07F)` != `0.1F + ((level - 1) * 0.07F)`
E.g. on level 3, that'd be a factor of 3.03 vs the intended 0.24!

P.S. I wrote a bigger refactor some time ago that I didn't finish and am currently going through all the changes so I'm gonna release them in hopefully soon in smaller batches.

Looks like one of the biggest damage bugs is already fixed via https://github.com/chronosacaria/MCDungeonsWeapons/commit/e8fe8e5a84caa05423449949de93affbd733dbf5.
(Before it would get the health from the target and set the health of any nearby targets to that value minus the damage - meaning if the target died, every other target would die too, regardless of their health.)