### PR TITLE
Refactor AbilityHelper

### DIFF
--- a/src/main/java/chronosacaria/mcdw/api/util/AOEHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AOEHelper.java
@@ -23,7 +23,7 @@ public class AOEHelper {
         World world = target.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, (LivingEntity) target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
             if (nearbyEntity instanceof PlayerEntity && ((PlayerEntity) nearbyEntity).abilities.creativeMode) return;
@@ -81,8 +81,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper
-                        .canApplyToEnemy(user, target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -97,7 +96,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
 
         if (nearbyEntities.isEmpty()) return;
         StatusEffectInstance chained = new StatusEffectInstance(StatusEffects.SLOWNESS, 100 * timeMultiplier, 100);
@@ -123,7 +122,7 @@ public class AOEHelper {
         float attackDamage = (float) user.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -139,7 +138,7 @@ public class AOEHelper {
         float h = target.getHealth();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -153,7 +152,7 @@ public class AOEHelper {
         float h = target.getHealth();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -168,7 +167,7 @@ public class AOEHelper {
         float attackDamage = (float) user.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, target, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity.isUndead()) {

--- a/src/main/java/chronosacaria/mcdw/api/util/AOEHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AOEHelper.java
@@ -19,11 +19,11 @@ import java.util.List;
 public class AOEHelper {
 
     //GRAVITY BEGIN
-    public static void pullInNearbyEntities(LivingEntity user, Entity target, int distance) {
+    public static void pullInNearbyEntities(LivingEntity user, LivingEntity target, int distance) {
         World world = target.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, target));
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
             if (nearbyEntity instanceof PlayerEntity && ((PlayerEntity) nearbyEntity).abilities.creativeMode) return;
@@ -59,7 +59,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(user.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, user));
+                (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, user, user));
         if (nearbyEntities.isEmpty()) return;
         if (limit > nearbyEntities.size()) limit = nearbyEntities.size();
         user.world.playSound(null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_LIGHTNING_BOLT_THUNDER,
@@ -81,7 +81,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, target));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -96,7 +96,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, target));
 
         if (nearbyEntities.isEmpty()) return;
         StatusEffectInstance chained = new StatusEffectInstance(StatusEffects.SLOWNESS, 100 * timeMultiplier, 100);
@@ -122,7 +122,7 @@ public class AOEHelper {
         float attackDamage = (float) user.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, target));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -137,8 +137,8 @@ public class AOEHelper {
         World world = target.getEntityWorld();
         float h = target.getHealth();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
-                new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+                new Box(user.getBlockPos()).expand(distance),
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, user));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -152,7 +152,7 @@ public class AOEHelper {
         float h = target.getHealth();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, target));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -167,7 +167,7 @@ public class AOEHelper {
         float attackDamage = (float) user.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user, target));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity.isUndead()) {

--- a/src/main/java/chronosacaria/mcdw/api/util/AOEHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AOEHelper.java
@@ -23,7 +23,7 @@ public class AOEHelper {
         World world = target.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
             if (nearbyEntity instanceof PlayerEntity && ((PlayerEntity) nearbyEntity).abilities.creativeMode) return;
@@ -59,7 +59,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(user.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+                (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, user));
         if (nearbyEntities.isEmpty()) return;
         if (limit > nearbyEntities.size()) limit = nearbyEntities.size();
         user.world.playSound(null, user.getX(), user.getY(), user.getZ(), SoundEvents.ENTITY_LIGHTNING_BOLT_THUNDER,
@@ -81,7 +81,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -96,7 +96,7 @@ public class AOEHelper {
 
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
 
         if (nearbyEntities.isEmpty()) return;
         StatusEffectInstance chained = new StatusEffectInstance(StatusEffects.SLOWNESS, 100 * timeMultiplier, 100);
@@ -122,7 +122,7 @@ public class AOEHelper {
         float attackDamage = (float) user.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -138,7 +138,7 @@ public class AOEHelper {
         float h = target.getHealth();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -152,7 +152,7 @@ public class AOEHelper {
         float h = target.getHealth();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity == null) return;
@@ -167,7 +167,7 @@ public class AOEHelper {
         float attackDamage = (float) user.getAttributeValue(EntityAttributes.GENERIC_ATTACK_DAMAGE);
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(target.getBlockPos()).expand(distance),
-            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+            (nearbyEntity) -> nearbyEntity != target && AbilityHelper.isAoeTarget(nearbyEntity, user));
         if (nearbyEntities.isEmpty()) return;
         for (LivingEntity nearbyEntity : nearbyEntities) {
             if (nearbyEntity.isUndead()) {

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -77,11 +77,6 @@ public class AbilityHelper {
         return (nearbyEntity instanceof VillagerEntity) || (nearbyEntity instanceof IronGolemEntity);
     }
 
-    private static boolean isNotTargetOrAttacker(LivingEntity user, LivingEntity target, LivingEntity nearbyEntity){
-        return nearbyEntity != target
-                && nearbyEntity != user;
-    }
-
     public static boolean canHealEntity(LivingEntity healer, LivingEntity nearbyEntity){
         return nearbyEntity != healer
                 && isAllyOf(healer, nearbyEntity)
@@ -99,7 +94,7 @@ public class AbilityHelper {
     }
 
     public static boolean canApplyToEnemy(LivingEntity user, LivingEntity target, LivingEntity nearbyEntity) {
-        return isNotTargetOrAttacker(user, target, nearbyEntity)
+        return nearbyEntity != target && nearbyEntity != user
                 && isAliveAndCanBeSeen(nearbyEntity, user)
                 && !isAllyOf(user, nearbyEntity)
                 && !isUnaffectedByAoe(nearbyEntity);

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -92,14 +92,14 @@ public class AbilityHelper {
 
     public static boolean canHealEntity(LivingEntity healer, LivingEntity nearbyEntity){
         return nearbyEntity != healer
-                && isAlly(healer, nearbyEntity)
+                && isAllyOf(healer, nearbyEntity)
                 && isAliveAndCanBeSeen(nearbyEntity, healer);
     }
 
-    private static boolean isAlly (LivingEntity healer, LivingEntity nearbyEntity){
-        return isPetOf(nearbyEntity, healer)
-                || isVillagerOrIronGolem(nearbyEntity)
-                || healer.isTeammate(nearbyEntity);
+    private static boolean isAllyOf(LivingEntity self, LivingEntity other) {
+        return self.isTeammate(other)
+            || isPetOf(self, other)
+            || isVillagerOrIronGolem(other);
     }
 
     private static boolean isAliveAndCanBeSeen (LivingEntity nearbyEntity, LivingEntity user){
@@ -109,14 +109,14 @@ public class AbilityHelper {
     public static boolean canApplyToEnemy(LivingEntity user, LivingEntity target, LivingEntity nearbyEntity) {
         return isNotTargetOrAttacker(user, target, nearbyEntity)
                 && isAliveAndCanBeSeen(nearbyEntity, user)
-                && !isAlly(user, nearbyEntity)
+                && !isAllyOf(user, nearbyEntity)
                 && isNotPlayerOrCanApplyToPlayers(nearbyEntity);
     }
 
     public static boolean canApplyToEnemy(LivingEntity attacker, LivingEntity nearbyEntity) {
         return nearbyEntity != attacker
                 && isAliveAndCanBeSeen(nearbyEntity, attacker)
-                && !isAlly(attacker, nearbyEntity)
+                && !isAllyOf(attacker, nearbyEntity)
                 && isNotPlayerOrCanApplyToPlayers(nearbyEntity);
     }
 

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -94,10 +94,7 @@ public class AbilityHelper {
     }
 
     public static boolean canApplyToEnemy(LivingEntity user, LivingEntity target, LivingEntity nearbyEntity) {
-        return nearbyEntity != target && nearbyEntity != user
-                && isAliveAndCanBeSeen(nearbyEntity, user)
-                && !isAllyOf(user, nearbyEntity)
-                && !isUnaffectedByAoe(nearbyEntity);
+        return nearbyEntity != target && canApplyToEnemy(user, nearbyEntity);
     }
 
     public static boolean canApplyToEnemy(LivingEntity attacker, LivingEntity nearbyEntity) {

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -43,31 +43,31 @@ public class AbilityHelper {
         AOEHelper.causeExplosionAttack(user, target, explodingDamage, 3.0F);
     }
 
-    public static boolean isPetOfUser(LivingEntity possibleOwner, LivingEntity possiblePet){
-        if (possiblePet instanceof TameableEntity){
-            TameableEntity pet = (TameableEntity) possiblePet;
-            return pet.getOwner() == possibleOwner;
+    public static boolean isPetOf(LivingEntity self, LivingEntity owner){
+        if (self instanceof TameableEntity){
+            TameableEntity pet = (TameableEntity) self;
+            return pet.getOwner() == owner;
         }
-        //if(possiblePet instanceof IronGolemEntity){
-        //    IronGolemEntity ironGolem = (IronGolemEntity) possiblePet;
-        //    return GoalUtils.getOwner(ironGolem) == possibleOwner;
+        //if(self instanceof IronGolemEntity){
+        //    IronGolemEntity ironGolem = (IronGolemEntity) self;
+        //    return GoalUtils.getOwner(ironGolem) == owner;
         //}
-        if(possiblePet instanceof HorseBaseEntity){
-            HorseBaseEntity horseBaseEntity = (HorseBaseEntity) possiblePet;
-            return GoalUtils.getOwner(horseBaseEntity) == possibleOwner;
+        if(self instanceof HorseBaseEntity){
+            HorseBaseEntity horseBaseEntity = (HorseBaseEntity) self;
+            return GoalUtils.getOwner(horseBaseEntity) == owner;
         }
 
-        //if(possiblePet instanceof BatEntity){
-        //    BatEntity batEntity = (BatEntity) possiblePet;
-        //    return GoalUtils.getOwner(batEntity) == possibleOwner;
+        //if(self instanceof BatEntity){
+        //    BatEntity batEntity = (BatEntity) self;
+        //    return GoalUtils.getOwner(batEntity) == owner;
         //}
-        //if(possiblePet instanceof BeeEntity){
-        //    BeeEntity beeEntity = (BeeEntity) possiblePet;
-        //    return GoalUtils.getOwner(beeEntity) == possibleOwner;
+        //if(self instanceof BeeEntity){
+        //    BeeEntity beeEntity = (BeeEntity) self;
+        //    return GoalUtils.getOwner(beeEntity) == owner;
         //}
-        //if(possiblePet instanceof SheepEntity){
-        //    SheepEntity sheepEntity = (SheepEntity) possiblePet;
-        //    return GoalUtils.getOwner(sheepEntity) == possibleOwner;
+        //if(self instanceof SheepEntity){
+        //    SheepEntity sheepEntity = (SheepEntity) self;
+        //    return GoalUtils.getOwner(sheepEntity) == owner;
         //}
 
         return false;
@@ -97,7 +97,7 @@ public class AbilityHelper {
     }
 
     private static boolean isAlly (LivingEntity healer, LivingEntity nearbyEntity){
-        return isPetOfUser(healer, nearbyEntity)
+        return isPetOf(nearbyEntity, healer)
                 || isVillagerOrIronGolem(nearbyEntity)
                 || healer.isTeammate(nearbyEntity);
     }

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -90,12 +90,12 @@ public class AbilityHelper {
             || isVillagerOrIronGolem(other);
     }
 
-    public static boolean canApplyToEnemy(LivingEntity attacker, LivingEntity nearbyEntity) {
-        return nearbyEntity != attacker
-            && nearbyEntity.isAlive()
-            && attacker.canSee(nearbyEntity)
-            && !isAllyOf(attacker, nearbyEntity)
-            && !isUnaffectedByAoe(nearbyEntity);
+    public static boolean isAoeTarget(LivingEntity self, LivingEntity attacker) {
+        return self != attacker
+            && self.isAlive()
+            && attacker.canSee(self)
+            && !isAllyOf(attacker, self)
+            && !isUnaffectedByAoe(self);
     }
 
     private static boolean isUnaffectedByAoe(LivingEntity entity) {

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -20,7 +20,7 @@ public class AbilityHelper {
 
     }
 
-    public static void causeFreesing(LivingEntity target, int amplifier){
+    public static void causeFreezing(LivingEntity target, int amplifier){
         StatusEffectInstance freezing = new StatusEffectInstance(StatusEffects.SLOWNESS, 60, amplifier);
         StatusEffectInstance miningFatigue = new StatusEffectInstance(StatusEffects.MINING_FATIGUE, 60, amplifier);
         target.addStatusEffect(freezing);

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -93,10 +93,6 @@ public class AbilityHelper {
         return nearbyEntity.isAlive() && user.canSee(nearbyEntity);
     }
 
-    public static boolean canApplyToEnemy(LivingEntity user, LivingEntity target, LivingEntity nearbyEntity) {
-        return nearbyEntity != target && canApplyToEnemy(user, nearbyEntity);
-    }
-
     public static boolean canApplyToEnemy(LivingEntity attacker, LivingEntity nearbyEntity) {
         return nearbyEntity != attacker
                 && isAliveAndCanBeSeen(nearbyEntity, attacker)

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -82,14 +82,6 @@ public class AbilityHelper {
                 && nearbyEntity != user;
     }
 
-    private static boolean isNotPlayerOrCanApplyToPlayers(LivingEntity nearbyEntity){
-        if (!(nearbyEntity instanceof PlayerEntity)){
-            return true;
-        } else {
-            return McdwEnchantsConfig.getValue("aoe_dont_affect_players");
-        }
-    }
-
     public static boolean canHealEntity(LivingEntity healer, LivingEntity nearbyEntity){
         return nearbyEntity != healer
                 && isAllyOf(healer, nearbyEntity)
@@ -110,14 +102,24 @@ public class AbilityHelper {
         return isNotTargetOrAttacker(user, target, nearbyEntity)
                 && isAliveAndCanBeSeen(nearbyEntity, user)
                 && !isAllyOf(user, nearbyEntity)
-                && isNotPlayerOrCanApplyToPlayers(nearbyEntity);
+                && !isUnaffectedByAoe(nearbyEntity);
     }
 
     public static boolean canApplyToEnemy(LivingEntity attacker, LivingEntity nearbyEntity) {
         return nearbyEntity != attacker
                 && isAliveAndCanBeSeen(nearbyEntity, attacker)
                 && !isAllyOf(attacker, nearbyEntity)
-                && isNotPlayerOrCanApplyToPlayers(nearbyEntity);
+                && !isUnaffectedByAoe(nearbyEntity);
+    }
+
+    private static boolean isUnaffectedByAoe(LivingEntity entity) {
+        if (entity instanceof PlayerEntity) {
+            PlayerEntity player = (PlayerEntity) entity;
+            if (player.isCreative()) return true;
+            return McdwEnchantsConfig.getValue("aoe_dont_affect_players");
+        }
+
+        return false;
     }
 
     // Have to figure out how to access targetSelector or figure out a different way to do this...

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -79,8 +79,9 @@ public class AbilityHelper {
 
     public static boolean canHealEntity(LivingEntity healer, LivingEntity nearbyEntity){
         return nearbyEntity != healer
-                && isAllyOf(healer, nearbyEntity)
-                && isAliveAndCanBeSeen(nearbyEntity, healer);
+            && isAllyOf(healer, nearbyEntity)
+            && nearbyEntity.isAlive()
+            && healer.canSee(nearbyEntity);
     }
 
     private static boolean isAllyOf(LivingEntity self, LivingEntity other) {
@@ -89,15 +90,12 @@ public class AbilityHelper {
             || isVillagerOrIronGolem(other);
     }
 
-    private static boolean isAliveAndCanBeSeen (LivingEntity nearbyEntity, LivingEntity user){
-        return nearbyEntity.isAlive() && user.canSee(nearbyEntity);
-    }
-
     public static boolean canApplyToEnemy(LivingEntity attacker, LivingEntity nearbyEntity) {
         return nearbyEntity != attacker
-                && isAliveAndCanBeSeen(nearbyEntity, attacker)
-                && !isAllyOf(attacker, nearbyEntity)
-                && !isUnaffectedByAoe(nearbyEntity);
+            && nearbyEntity.isAlive()
+            && attacker.canSee(nearbyEntity)
+            && !isAllyOf(attacker, nearbyEntity)
+            && !isUnaffectedByAoe(nearbyEntity);
     }
 
     private static boolean isUnaffectedByAoe(LivingEntity entity) {

--- a/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/AbilityHelper.java
@@ -90,12 +90,12 @@ public class AbilityHelper {
             || isVillagerOrIronGolem(other);
     }
 
-    public static boolean isAoeTarget(LivingEntity self, LivingEntity attacker) {
+    public static boolean isAoeTarget(LivingEntity self, LivingEntity attacker, LivingEntity center) {
         return self != attacker
             && self.isAlive()
-            && attacker.canSee(self)
             && !isAllyOf(attacker, self)
-            && !isUnaffectedByAoe(self);
+            && !isUnaffectedByAoe(self)
+            && center.canSee(self);
     }
 
     private static boolean isUnaffectedByAoe(LivingEntity entity) {

--- a/src/main/java/chronosacaria/mcdw/api/util/ProjectileEffectHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/ProjectileEffectHelper.java
@@ -28,7 +28,7 @@ public class ProjectileEffectHelper {
         World world = user.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(user.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, user));
+                (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, user, user));
         if(nearbyEntities.size() < 2) return;
         nearbyEntities.sort(Comparator.comparingDouble(livingEntity -> livingEntity.squaredDistanceTo(user)));
         LivingEntity target = nearbyEntities.get(0);
@@ -56,7 +56,7 @@ public class ProjectileEffectHelper {
         //boolean nullListFlag = arrowEntity.hitEntities == null;
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(attacker.getX() - distance, attacker.getY() - distance, attacker.getZ() - distance,
-                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, attacker));
+                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, attacker, attacker));
         if(nearbyEntities.size() < 2) return;
         nearbyEntities.sort(Comparator.comparingDouble(livingEntity -> livingEntity.squaredDistanceTo(attacker)));
         LivingEntity target =  nearbyEntities.get(0);
@@ -82,7 +82,7 @@ public class ProjectileEffectHelper {
         World world = attacker.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(attacker.getX() - distance, attacker.getY() - distance, attacker.getZ() - distance,
-                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, attacker));
+                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, attacker, attacker));
         if(nearbyEntities.size() < 2) return;
         nearbyEntities.sort(Comparator.comparingDouble(livingEntity -> livingEntity.squaredDistanceTo(attacker)));
         LivingEntity target =  nearbyEntities.get(0);

--- a/src/main/java/chronosacaria/mcdw/api/util/ProjectileEffectHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/ProjectileEffectHelper.java
@@ -28,7 +28,7 @@ public class ProjectileEffectHelper {
         World world = user.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(user.getBlockPos()).expand(distance),
-                (nearbyEntity) -> AbilityHelper.canApplyToEnemy(user, nearbyEntity));
+                (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, user));
         if(nearbyEntities.size() < 2) return;
         nearbyEntities.sort(Comparator.comparingDouble(livingEntity -> livingEntity.squaredDistanceTo(user)));
         LivingEntity target = nearbyEntities.get(0);
@@ -56,7 +56,7 @@ public class ProjectileEffectHelper {
         //boolean nullListFlag = arrowEntity.hitEntities == null;
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(attacker.getX() - distance, attacker.getY() - distance, attacker.getZ() - distance,
-                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.canApplyToEnemy(attacker, nearbyEntity));
+                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, attacker));
         if(nearbyEntities.size() < 2) return;
         nearbyEntities.sort(Comparator.comparingDouble(livingEntity -> livingEntity.squaredDistanceTo(attacker)));
         LivingEntity target =  nearbyEntities.get(0);
@@ -82,7 +82,7 @@ public class ProjectileEffectHelper {
         World world = attacker.getEntityWorld();
         List<LivingEntity> nearbyEntities = world.getEntitiesByClass(LivingEntity.class,
                 new Box(attacker.getX() - distance, attacker.getY() - distance, attacker.getZ() - distance,
-                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.canApplyToEnemy(attacker, nearbyEntity));
+                attacker.getX() + distance, attacker.getY() + distance, attacker.getZ() + distance), (nearbyEntity) -> AbilityHelper.isAoeTarget(nearbyEntity, attacker));
         if(nearbyEntities.size() < 2) return;
         nearbyEntities.sort(Comparator.comparingDouble(livingEntity -> livingEntity.squaredDistanceTo(attacker)));
         LivingEntity target =  nearbyEntities.get(0);

--- a/src/main/java/chronosacaria/mcdw/mixin/enchantments/FreezingEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/enchantments/FreezingEnchantmentMixin.java
@@ -3,7 +3,6 @@ package chronosacaria.mcdw.mixin.enchantments;
 import chronosacaria.mcdw.api.util.AbilityHelper;
 import chronosacaria.mcdw.configs.McdwEnchantsConfig;
 import chronosacaria.mcdw.enchants.EnchantsRegistry;
-import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.enchantment.EnchantmentHelper;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
@@ -37,7 +36,7 @@ public class FreezingEnchantmentMixin {
 
                         float chance = user.getRandom().nextFloat();
                         if (chance <= 0.3 + (level * 0.1)) {
-                            AbilityHelper.causeFreesing(target, 100);
+                            AbilityHelper.causeFreezing(target, 100);
                         }
                     }
                 }

--- a/src/main/java/chronosacaria/mcdw/mixin/enchantments/GravityShotEnchantmentMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/enchantments/GravityShotEnchantmentMixin.java
@@ -30,7 +30,7 @@ public abstract class GravityShotEnchantmentMixin extends Entity {
             return;
         }
         PersistentProjectileEntity persistentProjectileEntity = (PersistentProjectileEntity) (Object) this;
-        Entity target = entityHitResult.getEntity();
+        LivingEntity target = (LivingEntity) entityHitResult.getEntity();
         LivingEntity shooter = (LivingEntity) persistentProjectileEntity.getOwner();
         ItemStack mainHandStack = null;
         if (shooter != null) {
@@ -41,12 +41,10 @@ public abstract class GravityShotEnchantmentMixin extends Entity {
                 int level = EnchantmentHelper.getLevel(EnchantsRegistry.GRAVITY, mainHandStack);
                 float gravityShotRand = shooter.getRandom().nextFloat();
                 if (gravityShotRand <= 0.2F) {
-                    if (target instanceof LivingEntity) {
-                        AOEHelper.pullInNearbyEntities(
-                                shooter,
-                                target,
-                                (level + 1) * 3);
-                    }
+                    AOEHelper.pullInNearbyEntities(
+                            shooter,
+                            target,
+                            (level + 1) * 3);
                 }
             }
         }


### PR DESCRIPTION
As announced, here's another part of the refactor - since I had to redo it anyways, I made the commits as explicit as possible so you can follow along every step.

There's some things that should maybe be changed, e.g. looking at the "inline canApplyToEnemy" commit, you can see that most AOE effects exclude the original target, which is a little unintuitive for e.g. an explosion attack.
That said, I'm not sure if calling `damage()` on the already hit target will do anything because of invulnerability time, that'd need some testing, so for now I just left it as-is.

One bigger fix is about the "sightlines"/raycasts/`canSee` - previously, they would always start from the player, so enemies would sometimes not be hit, despite being in the AOE area.
The refactored `isAoeTarget` has a `center` parameter which chooses where the rays should cast from and I set it to the point where the AOE area is centered.

I also changed the swirling attack to center around the player, since that felt appropriate - the radius should probably be increased due to that.