### PR TITLE
Implement injection of MCDW stats into vanilla stats through overrides

### DIFF
--- a/src/main/java/chronosacaria/mcdw/api/util/RarityHelper.java
+++ b/src/main/java/chronosacaria/mcdw/api/util/RarityHelper.java
@@ -1,0 +1,16 @@
+package chronosacaria.mcdw.api.util;
+
+import net.minecraft.item.ToolMaterial;
+import net.minecraft.item.ToolMaterials;
+import net.minecraft.util.Rarity;
+
+public class RarityHelper {
+
+    public static Rarity fromToolMaterial(ToolMaterial material){
+        return
+            material == ToolMaterials.NETHERITE ? Rarity.EPIC :
+            material == ToolMaterials.DIAMOND ? Rarity.RARE :
+            material == ToolMaterials.GOLD ? Rarity.UNCOMMON :
+            material == ToolMaterials.IRON ? Rarity.UNCOMMON : Rarity.COMMON;
+    }
+}

--- a/src/main/java/chronosacaria/mcdw/bases/McdwAxe.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwAxe.java
@@ -1,8 +1,11 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.text.Text;
@@ -13,8 +16,8 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class McdwAxe extends AxeItem {
-    public McdwAxe(ToolMaterial material, float attackDamage, float attackSpeed, Settings settings){
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwAxe(ToolMaterial material, float attackDamage, float attackSpeed){
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwBow.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwBow.java
@@ -1,24 +1,19 @@
 
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IRangedWeapon;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
-import net.minecraft.enchantment.EnchantmentHelper;
-import net.minecraft.enchantment.Enchantments;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.entity.projectile.PersistentProjectileEntity;
-import net.minecraft.item.*;
+import net.minecraft.item.BowItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ToolMaterial;
 import net.minecraft.particle.ParticleEffect;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.stat.Stats;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 
@@ -32,28 +27,28 @@ public class McdwBow extends BowItem implements IRangedWeapon {
     public static float chargeTime = 30.0f;
 
     public final ToolMaterial material;
-    public final float maxDrawTime;
+    public final float drawSpeed;
     public static float maxBowRange;
     private final ParticleEffect type;
 
-    public McdwBow(ToolMaterial material, Settings settings, float maxDrawTime, float maxBowRangePar) {
-        super(settings);
-        this.material = material;
-        this.maxDrawTime = maxDrawTime;
-        maxBowRange = maxBowRangePar;
-        type = null;
+    public McdwBow(ToolMaterial material, float drawSpeed, float maxBowRangePar) {
+        this(material, drawSpeed, maxBowRangePar, null);
     }
 
-    public McdwBow(ToolMaterial material, Settings settings, float maxDrawTime, float maxBowRangePar, ParticleEffect particles) {
-        super(settings);
+    public McdwBow(ToolMaterial material, float drawSpeed, float maxBowRangePar, ParticleEffect particles) {
+        super(new Item.Settings().group(Mcdw.RANGED)
+                .maxCount(1)
+                .maxDamage(100 + material.getDurability())
+                .rarity(RarityHelper.fromToolMaterial(material))
+        );
         this.material = material;
-        this.maxDrawTime = maxDrawTime;
+        this.drawSpeed = drawSpeed;
         maxBowRange = maxBowRangePar;
         type = particles;
     }
 
-    public float getMaxDrawTime() {
-        return Math.max(0, maxDrawTime);
+    public float getDrawSpeed() {
+        return Math.max(0, drawSpeed);
     }
 
     public ParticleEffect getArrowParticles() {
@@ -77,7 +72,7 @@ public class McdwBow extends BowItem implements IRangedWeapon {
 
     @Override
     public int getMaxUseTime(ItemStack stack) {
-        return 72000;
+        return 72000 - (int)(drawSpeed);
     }
 
     @Override
@@ -91,9 +86,7 @@ public class McdwBow extends BowItem implements IRangedWeapon {
     }
 
     @Override
-    public int getRange() {
-        return 15;
-    }
+    public int getRange() { return (int)maxBowRange*2 + 10; }
 
     @Override
     public int getEnchantability() {

--- a/src/main/java/chronosacaria/mcdw/bases/McdwCrossbow.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwCrossbow.java
@@ -1,11 +1,11 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IRangedWeapon;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
-import net.minecraft.item.CrossbowItem;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.Items;
+import net.minecraft.item.*;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
@@ -14,28 +14,44 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class McdwCrossbow extends CrossbowItem implements IRangedWeapon {
+    public final ToolMaterial material;
+    public final float drawSpeed;
+    public final float range;
 
-    public McdwCrossbow(Settings settings) {
-        super(settings);
+    public McdwCrossbow(ToolMaterial material, float drawSpeed, float range) {
+        super(new Item.Settings().group(Mcdw.RANGED)
+                .maxCount(1)
+                .maxDamage(100 + material.getDurability())
+                .rarity(RarityHelper.fromToolMaterial(material))
+        );
+        this.material = material;
+        this.drawSpeed = drawSpeed;
+        this.range = range;
     }
 
     public float getProjectileVelocity(ItemStack stack){
         boolean fastProjectiles = shootsFasterArrows(stack);
         if (hasProjectile(stack, Items.FIREWORK_ROCKET)){
-            if (fastProjectiles){
-                return 3.2F;
-            }
-            else {
-                return 1.6F;
-            }
+            if (fastProjectiles) return 3.2F;
+            else return 1.6F;
         }
-        else if (fastProjectiles){
-            return 4.8F;
-        }
-        else {
-            return 3.2f;
-        }
+        else if (fastProjectiles) return 4.8F;
+        else return 3.2f;
     }
+
+    @Override
+    public int getRange() { return (int)range; }
+
+    @Override
+    public int getEnchantability() {
+        return material.getEnchantability();
+    }
+
+    @Override
+    public int getMaxUseTime(ItemStack stack) {
+        return getPullTime(stack) + 3 - (28 - (int)(drawSpeed));
+    }
+
 
     @Override
     public boolean isUsedOnRelease(ItemStack stack){

--- a/src/main/java/chronosacaria/mcdw/bases/McdwDagger.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwDagger.java
@@ -1,9 +1,12 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IOffhandAttack;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -18,8 +21,8 @@ import java.util.List;
 
 public class McdwDagger extends SwordItem implements IOffhandAttack {
 
-    public McdwDagger(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwDagger(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwDoubleAxe.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwDoubleAxe.java
@@ -1,8 +1,11 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.text.Text;
@@ -14,8 +17,8 @@ import java.util.List;
 
 public class McdwDoubleAxe extends AxeItem {
 
-    public McdwDoubleAxe(ToolMaterial material, float attackDamage, float attackSpeed, Settings settings){
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwDoubleAxe(ToolMaterial material, float attackDamage, float attackSpeed){
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwGauntlet.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwGauntlet.java
@@ -1,9 +1,12 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IOffhandAttack;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -18,8 +21,8 @@ import java.util.List;
 
 public class McdwGauntlet extends SwordItem implements IOffhandAttack {
 
-    public McdwGauntlet(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwGauntlet(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwGlaive.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwGlaive.java
@@ -1,5 +1,7 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -15,6 +17,7 @@ import net.minecraft.entity.attribute.EntityAttribute;
 import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -34,8 +37,8 @@ public class McdwGlaive extends SwordItem {
     private final ToolMaterial material;
     private final float attackDamage;
 
-    public McdwGlaive(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwGlaive(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
         this.material = material;
         this.attackDamage = attackDamage + material.getAttackDamage();
         ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();

--- a/src/main/java/chronosacaria/mcdw/bases/McdwHammer.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwHammer.java
@@ -1,7 +1,10 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -14,8 +17,8 @@ import java.util.List;
 
 // TODO change to AxeItem and make sure that they cannot strip logs
 public class McdwHammer extends SwordItem {
-    public McdwHammer(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwHammer(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwLongBow.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwLongBow.java
@@ -1,7 +1,9 @@
 
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IRangedWeapon;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -11,14 +13,10 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.*;
 import net.minecraft.particle.ParticleEffect;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.stat.Stats;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
+import net.minecraft.util.Rarity;
 import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 
@@ -32,28 +30,28 @@ public class McdwLongBow extends BowItem implements IRangedWeapon {
     public static float chargeTime = 60.0f;
 
     public final ToolMaterial material;
-    public final float maxDrawTime;
+    public final float drawSpeed;
     public static float maxBowRange;
     private final ParticleEffect type;
 
-    public McdwLongBow(ToolMaterial material, Settings settings, float maxDrawTime, float maxBowRangePar) {
-        super(settings);
-        this.material = material;
-        this.maxDrawTime = maxDrawTime;
-        maxBowRange = maxBowRangePar;
-        type = null;
+    public McdwLongBow(ToolMaterial material, float drawSpeed, float maxBowRangePar) {
+        this(material, drawSpeed, maxBowRangePar, null);
     }
 
-    public McdwLongBow(ToolMaterial material, Settings settings, float maxDrawTime, float maxBowRangePar, ParticleEffect particles) {
-        super(settings);
+    public McdwLongBow(ToolMaterial material, float drawSpeed, float maxBowRangePar, ParticleEffect particles) {
+        super(new Item.Settings().group(Mcdw.RANGED)
+                .maxCount(1)
+                .maxDamage(material.getDurability())
+                .rarity(RarityHelper.fromToolMaterial(material))
+        );
         this.material = material;
-        this.maxDrawTime = maxDrawTime;
+        this.drawSpeed = drawSpeed;
         maxBowRange = maxBowRangePar;
         type = particles;
     }
 
-    public float getMaxDrawTime() {
-        return Math.max(0, maxDrawTime);
+    public float getDrawSpeed() {
+        return Math.max(0, drawSpeed);
     }
 
     public ParticleEffect getArrowParticles() {
@@ -130,7 +128,7 @@ public class McdwLongBow extends BowItem implements IRangedWeapon {
 
     @Override
     public int getMaxUseTime(ItemStack stack) {
-        return 72000;
+        return 72000 - (int)(drawSpeed);
     }
 
     @Override
@@ -144,9 +142,7 @@ public class McdwLongBow extends BowItem implements IRangedWeapon {
     }
 
     @Override
-    public int getRange() {
-        return 15;
-    }
+    public int getRange() { return (int)maxBowRange*2 + 10; }
 
     @Override
     public int getEnchantability() {

--- a/src/main/java/chronosacaria/mcdw/bases/McdwPick.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwPick.java
@@ -1,7 +1,10 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.PickaxeItem;
 import net.minecraft.item.ToolMaterial;
@@ -13,8 +16,8 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class McdwPick extends PickaxeItem {
-    public McdwPick(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings){
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwPick(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwScythe.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwScythe.java
@@ -1,7 +1,10 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -13,8 +16,8 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class McdwScythe extends SwordItem {
-    public McdwScythe(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwScythe(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
     @Override
     public void appendTooltip(ItemStack stack, World world, List<Text> tooltip, TooltipContext tooltipContext) {

--- a/src/main/java/chronosacaria/mcdw/bases/McdwShield.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwShield.java
@@ -1,13 +1,13 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import net.minecraft.block.DispenserBlock;
 import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.ArmorItem;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ShieldItem;
-import net.minecraft.item.ToolMaterial;
+import net.minecraft.item.*;
 import net.minecraft.tag.ItemTags;
 import net.minecraft.util.Hand;
+import net.minecraft.util.Rarity;
 import net.minecraft.util.TypedActionResult;
 import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
@@ -16,10 +16,13 @@ public class McdwShield extends ShieldItem {
 
     public final ToolMaterial material;
 
-    public McdwShield(ToolMaterial material, Settings settings) {
-        super(settings);
+    public McdwShield(ToolMaterial material) {
+        super(new Item.Settings().group(Mcdw.SHIELDS)
+                .maxCount(1)
+                .maxDamage(250 + material.getDurability())
+                .rarity(RarityHelper.fromToolMaterial(material))
+        );
         this.material = material;
-
         DispenserBlock.registerBehavior(this, ArmorItem.DISPENSER_BEHAVIOR);
     }
 

--- a/src/main/java/chronosacaria/mcdw/bases/McdwShortBow.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwShortBow.java
@@ -1,7 +1,9 @@
 
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IRangedWeapon;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.enchantment.EnchantmentHelper;
@@ -11,15 +13,9 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.*;
 import net.minecraft.particle.ParticleEffect;
-import net.minecraft.sound.SoundCategory;
-import net.minecraft.sound.SoundEvents;
-import net.minecraft.stat.Stats;
 import net.minecraft.text.Text;
 import net.minecraft.text.TranslatableText;
-import net.minecraft.util.Formatting;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
-import net.minecraft.util.UseAction;
+import net.minecraft.util.*;
 import net.minecraft.world.World;
 
 import java.util.List;
@@ -32,28 +28,28 @@ public class McdwShortBow extends BowItem implements IRangedWeapon {
     public static float chargeTime = 15.0f;
 
     public final ToolMaterial material;
-    public final float maxDrawTime;
+    public final float drawSpeed;
     public static float maxBowRange;
     private final ParticleEffect type;
 
-    public McdwShortBow(ToolMaterial material, Settings settings, float maxDrawTime, float maxBowRangePar) {
-        super(settings);
-        this.material = material;
-        this.maxDrawTime = maxDrawTime;
-        maxBowRange = maxBowRangePar;
-        type = null;
+    public McdwShortBow(ToolMaterial material, float drawSpeed, float maxBowRangePar) {
+        this(material, drawSpeed, maxBowRangePar, null);
     }
 
-    public McdwShortBow(ToolMaterial material, Settings settings, float maxDrawTime, float maxBowRangePar, ParticleEffect particles) {
-        super(settings);
+    public McdwShortBow(ToolMaterial material, float drawSpeed, float maxBowRangePar, ParticleEffect particles) {
+        super(new Item.Settings().group(Mcdw.RANGED)
+                .maxCount(1)
+                .maxDamage(material.getDurability())
+                .rarity(RarityHelper.fromToolMaterial(material))
+        );
         this.material = material;
-        this.maxDrawTime = maxDrawTime;
+        this.drawSpeed = drawSpeed;
         maxBowRange = maxBowRangePar;
         type = particles;
     }
 
-    public float getMaxDrawTime() {
-        return Math.max(0, maxDrawTime);
+    public float getDrawSpeed() {
+        return Math.max(0, drawSpeed);
     }
 
     public ParticleEffect getArrowParticles() {
@@ -129,7 +125,7 @@ public class McdwShortBow extends BowItem implements IRangedWeapon {
 
     @Override
     public int getMaxUseTime(ItemStack stack) {
-        return 72000;
+        return 72000 - (int)(drawSpeed);
     }
 
     @Override
@@ -155,9 +151,7 @@ public class McdwShortBow extends BowItem implements IRangedWeapon {
     }
 
     @Override
-    public int getRange() {
-        return 15;
-    }
+    public int getRange() { return (int)maxBowRange*2 + 10; }
 
     @Override
     public int getEnchantability() {

--- a/src/main/java/chronosacaria/mcdw/bases/McdwSickle.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwSickle.java
@@ -1,9 +1,12 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.api.interfaces.IOffhandAttack;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
 import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -17,8 +20,8 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class McdwSickle extends SwordItem implements IOffhandAttack {
-    public McdwSickle(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwSickle(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwSoulDagger.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwSoulDagger.java
@@ -1,7 +1,10 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -13,8 +16,8 @@ import net.minecraft.world.World;
 import java.util.List;
 
 public class McdwSoulDagger extends SwordItem {
-    public McdwSoulDagger(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwSoulDagger(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
     @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwSpear.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwSpear.java
@@ -1,5 +1,7 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -16,6 +18,7 @@ import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.tag.BlockTags;
@@ -35,8 +38,8 @@ public class McdwSpear extends AxeItem {
     private final ToolMaterial material;
     private final float attackDamage;
 
-    public McdwSpear(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwSpear(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
         this.material = material;
         this.attackDamage = attackDamage + material.getAttackDamage();
         ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();

--- a/src/main/java/chronosacaria/mcdw/bases/McdwStaff.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwStaff.java
@@ -1,5 +1,7 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -16,6 +18,7 @@ import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.tag.BlockTags;
@@ -34,8 +37,8 @@ public class McdwStaff extends AxeItem {
     private final ToolMaterial material;
     private final float attackDamage;
 
-    public McdwStaff(ToolMaterial material, float attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwStaff(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
         this.material = material;
         this.attackDamage = attackDamage + material.getAttackDamage();
         ImmutableMultimap.Builder<EntityAttribute, EntityAttributeModifier> builder = ImmutableMultimap.builder();

--- a/src/main/java/chronosacaria/mcdw/bases/McdwSword.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwSword.java
@@ -1,7 +1,10 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import net.minecraft.client.item.TooltipContext;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.SwordItem;
 import net.minecraft.item.ToolMaterial;
@@ -14,8 +17,8 @@ import java.util.List;
 
 public class McdwSword extends SwordItem {
 
-    public McdwSword(ToolMaterial material, int attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwSword(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
     }
 
    @Override

--- a/src/main/java/chronosacaria/mcdw/bases/McdwWhip.java
+++ b/src/main/java/chronosacaria/mcdw/bases/McdwWhip.java
@@ -1,5 +1,7 @@
 package chronosacaria.mcdw.bases;
 
+import chronosacaria.mcdw.Mcdw;
+import chronosacaria.mcdw.api.util.RarityHelper;
 import chronosacaria.mcdw.items.ItemRegistry;
 import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.Multimap;
@@ -16,6 +18,7 @@ import net.minecraft.entity.attribute.EntityAttributeModifier;
 import net.minecraft.entity.attribute.EntityAttributes;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.AxeItem;
+import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ToolMaterial;
 import net.minecraft.tag.BlockTags;
@@ -35,8 +38,8 @@ public class McdwWhip extends AxeItem {
     private final ToolMaterial material;
     private final float attackDamage;
 
-    public McdwWhip(ToolMaterial material, float attackDamage, float attackSpeed, Settings settings) {
-        super(material, attackDamage, attackSpeed, settings);
+    public McdwWhip(ToolMaterial material, int attackDamage, float attackSpeed) {
+        super(material, attackDamage, attackSpeed, new Item.Settings().group(Mcdw.WEAPONS).rarity(RarityHelper.fromToolMaterial(material)));
         this.material = material;
         this.attackDamage = attackDamage + material.getAttackDamage();
         //this.typeSupplier = typeSupplier;

--- a/src/main/java/chronosacaria/mcdw/client/McdwClient.java
+++ b/src/main/java/chronosacaria/mcdw/client/McdwClient.java
@@ -44,7 +44,7 @@ public class McdwClient implements ClientModInitializer {
             if (livingEntity == null) {
                 return 0.0F;
             } else {
-                return livingEntity.getActiveItem() != itemStack ? 0.0F : (float)(itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / bow.getMaxDrawTime();
+                return livingEntity.getActiveItem() != itemStack ? 0.0F : (float)(itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / bow.getDrawSpeed();
             }
         });
 
@@ -56,7 +56,7 @@ public class McdwClient implements ClientModInitializer {
             if (livingEntity == null) {
                 return 0.0F;
             } else {
-                return livingEntity.getActiveItem() != itemStack ? 0.0F : (float)(itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / bow.getMaxDrawTime();
+                return livingEntity.getActiveItem() != itemStack ? 0.0F : (float)(itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / bow.getDrawSpeed();
             }
         });
 
@@ -68,7 +68,7 @@ public class McdwClient implements ClientModInitializer {
             if (livingEntity == null) {
                 return 0.0F;
             } else {
-                return livingEntity.getActiveItem() != itemStack ? 0.0F : (float)(itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / bow.getMaxDrawTime();
+                return livingEntity.getActiveItem() != itemStack ? 0.0F : (float)(itemStack.getMaxUseTime() - livingEntity.getItemUseTimeLeft()) / bow.getDrawSpeed();
             }
         });
 

--- a/src/main/java/chronosacaria/mcdw/configs/McdwStatsConfig.java
+++ b/src/main/java/chronosacaria/mcdw/configs/McdwStatsConfig.java
@@ -32,7 +32,7 @@ public class McdwStatsConfig {
     public static float getMaxRange(String item) {
         return RANGE.getOrDefault(item, 0f);
     }
-    public static float getDrawTime(String item) {
+    public static float getDrawSpeed(String item) {
         return DRAW_SPEED.getOrDefault(item, 0f);
     }
 
@@ -45,18 +45,18 @@ public class McdwStatsConfig {
     }
 
     public static void initDrawSpeed() {
-        DRAW_SPEED.put("bow_ancient_bow", 15f);
-        DRAW_SPEED.put("bow_bonebow", 15f);
-        DRAW_SPEED.put("bow_burst_gale_bow", 15f);
-        DRAW_SPEED.put("bow_echo_of_the_valley", 15f);
+        DRAW_SPEED.put("bow_ancient_bow", 12f);
+        DRAW_SPEED.put("bow_bonebow", 16f);
+        DRAW_SPEED.put("bow_burst_gale_bow", 10f);
+        DRAW_SPEED.put("bow_echo_of_the_valley", 9f);
         DRAW_SPEED.put("bow_elite_power_bow", 20f);
-        DRAW_SPEED.put("bow_green_menace", 15f);
+        DRAW_SPEED.put("bow_green_menace", 16f);
         DRAW_SPEED.put("bow_guardian_bow", 30f);
-        DRAW_SPEED.put("bow_haunted_bow", 15f);
-        DRAW_SPEED.put("bow_hunters_promise", 15f);
-        DRAW_SPEED.put("bow_hunting_bow", 15f);
+        DRAW_SPEED.put("bow_haunted_bow", 28f);
+        DRAW_SPEED.put("bow_hunters_promise", 13f);
+        DRAW_SPEED.put("bow_hunting_bow", 14f);
         DRAW_SPEED.put("bow_longbow", 20f);
-        DRAW_SPEED.put("bow_lost_souls", 15f);
+        DRAW_SPEED.put("bow_lost_souls", 8f);
         DRAW_SPEED.put("bow_love_spell_bow", 8f);
         DRAW_SPEED.put("bow_masters_bow", 15f);
         DRAW_SPEED.put("bow_mechanical_shortbow", 8f);
@@ -65,92 +65,144 @@ public class McdwStatsConfig {
         DRAW_SPEED.put("bow_power_bow", 20f);
         DRAW_SPEED.put("bow_purple_storm", 8f);
         DRAW_SPEED.put("bow_red_snake", 30f);
-        DRAW_SPEED.put("bow_sabrewing", 15f);
-        DRAW_SPEED.put("bow_shivering_bow", 15f);
+        DRAW_SPEED.put("bow_sabrewing", 8f);
+        DRAW_SPEED.put("bow_shivering_bow", 12f);
         DRAW_SPEED.put("bow_shortbow", 8f);
-        DRAW_SPEED.put("bow_soul_bow", 15f);
-        DRAW_SPEED.put("bow_trickbow", 15f);
-        DRAW_SPEED.put("bow_wind_bow", 15f);
-        DRAW_SPEED.put("bow_snow_bow", 15f);
-        DRAW_SPEED.put("bow_winters_touch", 15f);
+        DRAW_SPEED.put("bow_soul_bow", 12f);
+        DRAW_SPEED.put("bow_trickbow", 10f);
+        DRAW_SPEED.put("bow_wind_bow", 9f);
+        DRAW_SPEED.put("bow_snow_bow", 14f);
+        DRAW_SPEED.put("bow_winters_touch", 13f);
+
+        DRAW_SPEED.put("crossbow_the_slicer", 28f);
+        DRAW_SPEED.put("crossbow_azure_seeker", 28f);
+        DRAW_SPEED.put("crossbow_exploding_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_imploding_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_firebolt_thrower", 28f);
+        DRAW_SPEED.put("crossbow_heavy_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_doom_crossbow", 26f);
+        DRAW_SPEED.put("crossbow_slayer_crossbow", 26f);
+        DRAW_SPEED.put("crossbow_rapid_crossbow", 20f);
+        DRAW_SPEED.put("crossbow_butterfly_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_auto_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_scatter_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_harp_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_lightning_harp_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_soul_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_feral_soul_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_voidcaller_crossbow", 26f);
+        DRAW_SPEED.put("crossbow_dual_crossbow", 24f);
+        DRAW_SPEED.put("crossbow_spellbound_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_baby_crossbow", 23f);
+        DRAW_SPEED.put("crossbow_burst_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_soul_hunter_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_corrupted_crossbow", 22f);
+        DRAW_SPEED.put("crossbow_cog_crossbow", 28f);
+        DRAW_SPEED.put("crossbow_pride_of_the_piglins", 20f);
     }
 
     public static void initRange() {
-        RANGE.put("bow_ancient_bow", 3.2f);
-        RANGE.put("bow_bonebow", 3.2f);
-        RANGE.put("bow_burst_gale_bow", 3.2f);
-        RANGE.put("bow_echo_of_the_valley", 3.2f);
+        RANGE.put("bow_ancient_bow", 7.6f);
+        RANGE.put("bow_bonebow", 3.4f);
+        RANGE.put("bow_burst_gale_bow", 7.2f);
+        RANGE.put("bow_echo_of_the_valley", 7.4f);
         RANGE.put("bow_elite_power_bow", 6.4f);
-        RANGE.put("bow_green_menace", 3.2f);
+        RANGE.put("bow_green_menace", 4.0f);
         RANGE.put("bow_guardian_bow", 6.4f);
-        RANGE.put("bow_haunted_bow", 3.2f);
-        RANGE.put("bow_hunters_promise", 3.2f);
-        RANGE.put("bow_hunting_bow", 3.2f);
-        RANGE.put("bow_longbow", 6.4f);
-        RANGE.put("bow_lost_souls", 3.2f);
+        RANGE.put("bow_haunted_bow", 7.0f);
+        RANGE.put("bow_hunters_promise", 5.0f);
+        RANGE.put("bow_hunting_bow", 4.6f);
+        RANGE.put("bow_longbow", 7.0f);
+        RANGE.put("bow_lost_souls", 7.4f);
         RANGE.put("bow_love_spell_bow", 2f);
-        RANGE.put("bow_masters_bow", 3.2f);
-        RANGE.put("bow_mechanical_shortbow", 2f);
-        RANGE.put("bow_nocturnal_bow", 3.2f);
-        RANGE.put("bow_pink_scoundrel", 3.2f);
+        RANGE.put("bow_masters_bow", 4.4f);
+        RANGE.put("bow_mechanical_shortbow", 2.6f);
+        RANGE.put("bow_nocturnal_bow", 6.0f);
+        RANGE.put("bow_pink_scoundrel", 5.6f);
         RANGE.put("bow_power_bow", 6.4f);
         RANGE.put("bow_purple_storm", 2f);
-        RANGE.put("bow_red_snake", 6.4f);
-        RANGE.put("bow_sabrewing", 3.2f);
-        RANGE.put("bow_shivering_bow", 3.2f);
+        RANGE.put("bow_red_snake", 8.4f);
+        RANGE.put("bow_sabrewing", 9.0f);
+        RANGE.put("bow_shivering_bow", 4.0f);
         RANGE.put("bow_shortbow", 2f);
-        RANGE.put("bow_soul_bow", 3.2f);
-        RANGE.put("bow_trickbow", 3.2f);
-        RANGE.put("bow_wind_bow", 3.2f);
-        RANGE.put("bow_snow_bow", 3.2f);
-        RANGE.put("bow_winters_touch", 3.2f);
-        RANGE.put("bow_twisting_vine_bow", 3.2f);
-        RANGE.put("bow_weeping_vine_bow", 3.2f);
+        RANGE.put("bow_soul_bow", 4.0f);
+        RANGE.put("bow_trickbow", 4.2f);
+        RANGE.put("bow_wind_bow", 6.8f);
+        RANGE.put("bow_snow_bow", 4.8f);
+        RANGE.put("bow_winters_touch", 5.2f);
+        RANGE.put("bow_twisting_vine_bow", 4.0f);
+        RANGE.put("bow_weeping_vine_bow", 4.0f);
+
+        RANGE.put("crossbow_the_slicer", 10.2f);
+        RANGE.put("crossbow_azure_seeker", 8.4f);
+        RANGE.put("crossbow_exploding_crossbow", 8.0f);
+        RANGE.put("crossbow_imploding_crossbow", 8.0f);
+        RANGE.put("crossbow_firebolt_thrower", 7.9f);
+        RANGE.put("crossbow_heavy_crossbow", 8.0f);
+        RANGE.put("crossbow_doom_crossbow", 8.0f);
+        RANGE.put("crossbow_slayer_crossbow", 8.8f);
+        RANGE.put("crossbow_rapid_crossbow", 8.2f);
+        RANGE.put("crossbow_butterfly_crossbow", 8.9f);
+        RANGE.put("crossbow_auto_crossbow", 8.0f);
+        RANGE.put("crossbow_scatter_crossbow", 8.0f);
+        RANGE.put("crossbow_harp_crossbow", 8.6f);
+        RANGE.put("crossbow_lightning_harp_crossbow", 14.2f);
+        RANGE.put("crossbow_soul_crossbow", 8.0f);
+        RANGE.put("crossbow_feral_soul_crossbow", 9.2f);
+        RANGE.put("crossbow_voidcaller_crossbow", 12.5f);
+        RANGE.put("crossbow_dual_crossbow", 7.0f);
+        RANGE.put("crossbow_spellbound_crossbow", 8.9f);
+        RANGE.put("crossbow_baby_crossbow", 7.2f);
+        RANGE.put("crossbow_burst_crossbow", 8.0f);
+        RANGE.put("crossbow_soul_hunter_crossbow", 11.0f);
+        RANGE.put("crossbow_corrupted_crossbow", 14.0f);
+        RANGE.put("crossbow_cog_crossbow", 8.4f);
+        RANGE.put("crossbow_pride_of_the_piglins", 13.0f);
     }
 
     public static void initMaterial() {
+        // swords
         MATERIAL.put("sword_claymore", ToolMaterials.IRON);
         MATERIAL.put("sword_broadsword", ToolMaterials.IRON);
         MATERIAL.put("sword_frost_slayer", ToolMaterials.DIAMOND);
         MATERIAL.put("sword_heartstealer", ToolMaterials.DIAMOND);
         MATERIAL.put("sword_great_axeblade", ToolMaterials.IRON);
-
         MATERIAL.put("sword_rapier", ToolMaterials.IRON);
         MATERIAL.put("sword_beestinger", ToolMaterials.DIAMOND);
         MATERIAL.put("sword_freezing_foil", ToolMaterials.DIAMOND);
-
         MATERIAL.put("sword_cutlass", ToolMaterials.IRON);
         MATERIAL.put("sword_nameless_blade", ToolMaterials.DIAMOND);
         MATERIAL.put("sword_dancers_sword", ToolMaterials.IRON);
-
         MATERIAL.put("sword_katana", ToolMaterials.IRON);
         MATERIAL.put("sword_masters_katana", ToolMaterials.DIAMOND);
         MATERIAL.put("sword_dark_katana", ToolMaterials.NETHERITE);
-
         MATERIAL.put("sword_iron_sword_var", ToolMaterials.IRON);
         MATERIAL.put("sword_diamond_sword_var", ToolMaterials.DIAMOND);
         MATERIAL.put("sword_hawkbrand", ToolMaterials.IRON);
-
         MATERIAL.put("sword_broken_sawblade", ToolMaterials.IRON);
-        MATERIAL.put("sword_mechanized_sawblade", ToolMaterials.DIAMOND);
+        MATERIAL.put("sword_mechanized_sawblade", ToolMaterials.NETHERITE);
+        MATERIAL.put("sword_truthseeker", ToolMaterials.NETHERITE);
 
+        // axes
         MATERIAL.put("axe", ToolMaterials.IRON);
         MATERIAL.put("axe_firebrand", ToolMaterials.DIAMOND);
         MATERIAL.put("axe_highland", ToolMaterials.IRON);
-
         MATERIAL.put("axe_cursed", ToolMaterials.IRON);
         MATERIAL.put("axe_double", ToolMaterials.IRON);
         MATERIAL.put("axe_whirlwind", ToolMaterials.IRON);
 
+        // daggers
         MATERIAL.put("dagger_dagger", ToolMaterials.IRON);
         MATERIAL.put("dagger_fangs_of_frost", ToolMaterials.IRON);
         MATERIAL.put("dagger_moon", ToolMaterials.IRON);
         MATERIAL.put("dagger_shear_dagger", ToolMaterials.IRON);
-
         MATERIAL.put("dagger_soul_knife", ToolMaterials.IRON);
-        MATERIAL.put("dagger_eternal_knife", ToolMaterials.DIAMOND);
-        MATERIAL.put("sword_truthseeker", ToolMaterials.IRON);
+        MATERIAL.put("dagger_eternal_knife", ToolMaterials.NETHERITE);
+        MATERIAL.put("dagger_tempest_knife", ToolMaterials.IRON);
+        MATERIAL.put("dagger_resolute_tempest_knife", ToolMaterials.IRON);
+        MATERIAL.put("dagger_chill_gale_knife", ToolMaterials.IRON);
 
+        // hammers
         MATERIAL.put("hammer_great", ToolMaterials.IRON);
         MATERIAL.put("hammer_stormlander", ToolMaterials.DIAMOND);
         MATERIAL.put("hammer_gravity", ToolMaterials.DIAMOND);
@@ -160,74 +212,109 @@ public class McdwStatsConfig {
         MATERIAL.put("hammer_boneclub", ToolMaterials.IRON);
         MATERIAL.put("hammer_bone_cudgel", ToolMaterials.DIAMOND);
 
-        MATERIAL.put("dagger_tempest_knife", ToolMaterials.IRON);
-        MATERIAL.put("dagger_resolute_tempest_knife", ToolMaterials.IRON);
-        MATERIAL.put("dagger_chill_gale_knife", ToolMaterials.IRON);
 
+        // gauntlets
         MATERIAL.put("gauntlet_gauntlet", ToolMaterials.IRON);
         MATERIAL.put("gauntlet_fighters_bindings", ToolMaterials.IRON);
         MATERIAL.put("gauntlet_maulers", ToolMaterials.DIAMOND);
         MATERIAL.put("gauntlet_soul_fists", ToolMaterials.NETHERITE);
 
+        // sickles
         MATERIAL.put("sickle_sickle", ToolMaterials.IRON);
         MATERIAL.put("sickle_nightmares_bite", ToolMaterials.IRON);
         MATERIAL.put("sickle_last_laugh_gold", ToolMaterials.GOLD);
         MATERIAL.put("sickle_last_laugh_silver", ToolMaterials.GOLD);
-
         MATERIAL.put("sickle_jailors_scythe", ToolMaterials.IRON);
         MATERIAL.put("sickle_soul_scythe", ToolMaterials.DIAMOND);
         MATERIAL.put("sickle_frost_scythe", ToolMaterials.IRON);
 
+        // picks
         MATERIAL.put("pick_diamond_pickaxe_var", ToolMaterials.DIAMOND);
         MATERIAL.put("pick_mountaineer_pick", ToolMaterials.IRON);
         MATERIAL.put("pick_howling_pick", ToolMaterials.IRON);
         MATERIAL.put("pick_hailing_pinnacle", ToolMaterials.DIAMOND);
 
+        // spears
         MATERIAL.put("spear_glaive", ToolMaterials.IRON);
         MATERIAL.put("spear_grave_bane", ToolMaterials.IRON);
         MATERIAL.put("spear_venom_glaive", ToolMaterials.IRON);
 
+        // spears
         MATERIAL.put("spear_spear", ToolMaterials.IRON);
         MATERIAL.put("spear_whispering_spear", ToolMaterials.IRON);
         MATERIAL.put("spear_fortune", ToolMaterials.GOLD);
 
+        // staffs
         MATERIAL.put("staff_battlestaff", ToolMaterials.WOOD);
         MATERIAL.put("staff_growing_staff", ToolMaterials.IRON);
         MATERIAL.put("staff_battlestaff_of_terror", ToolMaterials.IRON);
 
+        // whips
         MATERIAL.put("whip_whip", ToolMaterials.IRON);
         MATERIAL.put("whip_vine_whip", ToolMaterials.IRON);
 
-        MATERIAL.put("bow_ancient_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_bonebow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_burst_gale_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_echo_of_the_valley", ToolMaterials.WOOD);
-        MATERIAL.put("bow_elite_power_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_green_menace", ToolMaterials.WOOD);
-        MATERIAL.put("bow_guardian_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_haunted_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_hunters_promise", ToolMaterials.WOOD);
+        // bows
+        MATERIAL.put("bow_ancient_bow", ToolMaterials.NETHERITE);
+        MATERIAL.put("bow_bonebow", ToolMaterials.STONE);
+        MATERIAL.put("bow_burst_gale_bow", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_echo_of_the_valley", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_elite_power_bow", ToolMaterials.IRON);
+        MATERIAL.put("bow_green_menace", ToolMaterials.IRON);
+        MATERIAL.put("bow_guardian_bow", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_haunted_bow", ToolMaterials.NETHERITE);
+        MATERIAL.put("bow_hunters_promise", ToolMaterials.STONE);
         MATERIAL.put("bow_hunting_bow", ToolMaterials.WOOD);
         MATERIAL.put("bow_longbow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_lost_souls", ToolMaterials.WOOD);
-        MATERIAL.put("bow_love_spell_bow", ToolMaterials.WOOD);
+        MATERIAL.put("bow_lost_souls", ToolMaterials.NETHERITE);
+        MATERIAL.put("bow_love_spell_bow", ToolMaterials.GOLD);
         MATERIAL.put("bow_masters_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_mechanical_shortbow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_nocturnal_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_pink_scoundrel", ToolMaterials.WOOD);
-        MATERIAL.put("bow_power_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_purple_storm", ToolMaterials.WOOD);
-        MATERIAL.put("bow_red_snake", ToolMaterials.WOOD);
-        MATERIAL.put("bow_sabrewing", ToolMaterials.WOOD);
-        MATERIAL.put("bow_shivering_bow", ToolMaterials.WOOD);
+        MATERIAL.put("bow_mechanical_shortbow", ToolMaterials.IRON);
+        MATERIAL.put("bow_nocturnal_bow", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_pink_scoundrel", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_power_bow", ToolMaterials.IRON);
+        MATERIAL.put("bow_purple_storm", ToolMaterials.IRON);
+        MATERIAL.put("bow_red_snake", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_sabrewing", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_shivering_bow", ToolMaterials.DIAMOND);
         MATERIAL.put("bow_shortbow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_soul_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_trickbow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_wind_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_snow_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_winters_touch", ToolMaterials.WOOD);
-        MATERIAL.put("bow_twisting_vine_bow", ToolMaterials.WOOD);
-        MATERIAL.put("bow_weeping_vine_bow", ToolMaterials.WOOD);
+        MATERIAL.put("bow_snow_bow", ToolMaterials.IRON);
+        MATERIAL.put("bow_soul_bow", ToolMaterials.IRON);
+        MATERIAL.put("bow_trickbow", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_wind_bow", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_winters_touch", ToolMaterials.DIAMOND);
+        MATERIAL.put("bow_twisting_vine_bow", ToolMaterials.IRON);
+        MATERIAL.put("bow_weeping_vine_bow", ToolMaterials.IRON);
+
+        // crossbows
+        MATERIAL.put("crossbow_the_slicer", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_azure_seeker", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_exploding_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_imploding_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_firebolt_thrower", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_heavy_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_doom_crossbow", ToolMaterials.NETHERITE);
+        MATERIAL.put("crossbow_slayer_crossbow", ToolMaterials.DIAMOND);
+        MATERIAL.put("crossbow_rapid_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_butterfly_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_auto_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_scatter_crossbow", ToolMaterials.WOOD);
+        MATERIAL.put("crossbow_harp_crossbow", ToolMaterials.GOLD);
+        MATERIAL.put("crossbow_lightning_harp_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_soul_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_feral_soul_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_voidcaller_crossbow", ToolMaterials.DIAMOND);
+        MATERIAL.put("crossbow_dual_crossbow", ToolMaterials.WOOD);
+        MATERIAL.put("crossbow_spellbound_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_baby_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_burst_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_soul_hunter_crossbow", ToolMaterials.DIAMOND);
+        MATERIAL.put("crossbow_corrupted_crossbow", ToolMaterials.NETHERITE);
+        MATERIAL.put("crossbow_cog_crossbow", ToolMaterials.IRON);
+        MATERIAL.put("crossbow_pride_of_the_piglins", ToolMaterials.NETHERITE);
+
+        // shields
+        MATERIAL.put("shield_royal_guard", ToolMaterials.DIAMOND);
+        MATERIAL.put("shield_vanguard", ToolMaterials.IRON);
     }
 
     public static void initDamage() {
@@ -278,7 +365,7 @@ public class McdwStatsConfig {
         DAMAGE.put("dagger_shear_dagger", 1f);
 
         DAMAGE.put("dagger_soul_knife", 1f);
-        DAMAGE.put("dagger_eternal_knife", 0f);
+        DAMAGE.put("dagger_eternal_knife", 4f);
         DAMAGE.put("sword_truthseeker", 3f);
 
         //Hammers

--- a/src/main/java/chronosacaria/mcdw/items/ItemRegistry.java
+++ b/src/main/java/chronosacaria/mcdw/items/ItemRegistry.java
@@ -191,81 +191,79 @@ public class ItemRegistry {
 
         //Swords
         for (String itemID : SWORDS) {
-            ITEMS.put(itemID, new McdwSword(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwSword(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //AXES
         for (String itemID : AXES) {
-            ITEMS.put(itemID, new McdwAxe(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwAxe(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //DOUBLE AXES
         for (String itemID : DOUBLE_AXES) {
-            ITEMS.put(itemID, new McdwDoubleAxe(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwDoubleAxe(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //DAGGERS
         for (String itemID : DAGGERS) {
-            ITEMS.put(itemID, new McdwDagger(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwDagger(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //SOUL DAGGERS
         for (String itemID : SOUL_DAGGERS) {
-            ITEMS.put(itemID, new McdwSoulDagger(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwSoulDagger(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //HAMMERS
         for (String itemID : HAMMERS) {
-            ITEMS.put(itemID, new McdwHammer(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwHammer(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //GAUNTLETS
         for (String itemID : GAUNTLETS) {
-            ITEMS.put(itemID, new McdwGauntlet(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwGauntlet(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //SICKLES
         for (String itemID : SICKLES) {
-            ITEMS.put(itemID, new McdwSickle(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwSickle(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //SCYTHES
         for (String itemID : SCYTHES) {
-            ITEMS.put(itemID, new McdwScythe(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwScythe(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //PICKS
         for (String itemID : PICKS) {
-            ITEMS.put(itemID, new McdwPick(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwPick(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //GLAIVES
         for (String itemID : GLAIVES) {
-            ITEMS.put(itemID, new McdwGlaive(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwGlaive(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //SPEARS
         for (String itemID : SPEARS) {
-            ITEMS.put(itemID, new McdwSpear(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwSpear(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //STAVES
         for (String itemID : STAVES) {
-            ITEMS.put(itemID, new McdwStaff(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwStaff(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //WHIPS
         for (String itemID : WHIPS) {
-            ITEMS.put(itemID, new McdwWhip(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID), new Item.Settings().group(Mcdw.WEAPONS)));
+            ITEMS.put(itemID, new McdwWhip(McdwStatsConfig.getMaterial(itemID), (int) McdwStatsConfig.getDamage(itemID), McdwStatsConfig.getSpeed(itemID)));
         }
         //BOWS
         for (String itemID : BOWS) {
-            ITEMS.put(itemID, new McdwBow(McdwStatsConfig.getMaterial(itemID), new Item.Settings().group(Mcdw.RANGED).maxCount(1).maxDamage(350), McdwStatsConfig.getDrawTime(itemID), McdwStatsConfig.getMaxRange(itemID)));
+            ITEMS.put(itemID, new McdwBow(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDrawSpeed(itemID), McdwStatsConfig.getMaxRange(itemID)));
         }
         //SHORTBOWS
         for (String itemID : SHORTBOWS) {
-            ITEMS.put(itemID, new McdwShortBow(McdwStatsConfig.getMaterial(itemID), new Item.Settings().group(Mcdw.RANGED).maxCount(1).maxDamage(350), McdwStatsConfig.getDrawTime(itemID), McdwStatsConfig.getMaxRange(itemID)));
+            ITEMS.put(itemID, new McdwShortBow(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDrawSpeed(itemID), McdwStatsConfig.getMaxRange(itemID)));
         }
         //LONGBOWS
         for (String itemID : LONGBOWS) {
-            ITEMS.put(itemID, new McdwLongBow(McdwStatsConfig.getMaterial(itemID),
-                    new Item.Settings().group(Mcdw.RANGED).maxCount(1).maxDamage(350), McdwStatsConfig.getDrawTime(itemID), McdwStatsConfig.getMaxRange(itemID)));
+            ITEMS.put(itemID, new McdwLongBow(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDrawSpeed(itemID), McdwStatsConfig.getMaxRange(itemID)));
         }
         //CROSSBOWS
         for (String itemID : CROSSBOWS) {
-            ITEMS.put(itemID, new McdwCrossbow(new Item.Settings().group(Mcdw.RANGED).maxCount(1).maxDamage(350)));
+            ITEMS.put(itemID, new McdwCrossbow(McdwStatsConfig.getMaterial(itemID), McdwStatsConfig.getDrawSpeed(itemID), McdwStatsConfig.getMaxRange(itemID)));
         }
         //SHIELDS
         for (String itemID : SHIELDS) {
-            ITEMS.put(itemID, new McdwShield(McdwStatsConfig.getMaterial(itemID),
-                    new Item.Settings().group(Mcdw.SHIELDS).maxCount(1).maxDamage(500)));
+            ITEMS.put(itemID, new McdwShield(McdwStatsConfig.getMaterial(itemID)));
         }
 
     }


### PR DESCRIPTION
- MCDW weapons now override vanilla rarity
- Bows & crossbows now inject their draw speed, range, and rarity into vanilla settings
- Added crossbow range, material, and speed stats
- Modified weapon materials based on crafting recipes
- Modified some other stats for balancing

This was done so that other mods (primarily Age of Exile) can properly handle MCDW with its auto-compatibility settings.