### PR TITLE
Improve claymore scales

### DIFF
--- a/src/main/resources/assets/mcdw/models/item/model_broadsword.json
+++ b/src/main/resources/assets/mcdw/models/item/model_broadsword.json
@@ -6,22 +6,22 @@
 		"thirdperson_righthand": {
 			"rotation": [0, 90, 55],
 			"translation": [0, 5.25, 2.5],
-			"scale": [1.7, 1.7, 0.85]
+			"scale": [2.0, 2.0, 0.85]
 		},
 		"thirdperson_lefthand": {
 			"rotation": [0, -90, -55],
 			"translation": [0, 5.25, 2.5],
-			"scale": [1.7, 1.7, 0.85]
+			"scale": [2.0, 2.0, 0.85]
 		},
 		"firstperson_righthand": {
 			"rotation": [0, -90, 25],
 			"translation": [1.13, 3.2, 1.13],
-			"scale": [1.36, 1.36, 0.68]
+			"scale": [1.5, 1.5, 0.68]
 		},
 		"firstperson_lefthand": {
 			"rotation": [0, 90, -25],
 			"translation": [1.13, 3.2, 1.13],
-			"scale": [1.36, 1.36, 0.68]
+			"scale": [1.5, 1.5, 0.68]
 		},
 		"ground": {
 			"translation": [0, 2, 0],

--- a/src/main/resources/assets/mcdw/models/item/model_claymore.json
+++ b/src/main/resources/assets/mcdw/models/item/model_claymore.json
@@ -19,23 +19,23 @@
     },
     "thirdperson_righthand": {
       "rotation": [ 0, -90, 55 ],
-      "translation": [ 0, 4.0, 0.5 ],
-      "scale": [ 1.70, 1.70, 0.85 ]
+      "translation": [ 0, 5.0, 0.5 ],
+      "scale": [ 2, 2, 0.85 ]
     },
     "thirdperson_lefthand": {
       "rotation": [ 0, 90, -55 ],
-      "translation": [ 0, 4.0, 0.5 ],
-      "scale": [ 1.70, 1.70, 0.85 ]
+      "translation": [ 0, 5.0, 0.5 ],
+      "scale": [ 2, 2, 0.85 ]
     },
     "firstperson_righthand": {
       "rotation": [ 0, -90, 25 ],
       "translation": [ 1.13, 3.2, 1.13 ],
-      "scale": [ 1.36, 1.36, 0.68 ]
+      "scale": [ 1.5, 1.5, 0.68 ]
     },
     "firstperson_lefthand": {
       "rotation": [ 0, 90, -25 ],
       "translation": [ 1.13, 3.2, 1.13 ],
-      "scale": [ 1.36, 1.36, 0.68 ]
+      "scale": [ 1.5, 1.5, 0.68 ]
     },
     "fixed": {
       "rotation": [ 0, 180, 0 ],

--- a/src/main/resources/assets/mcdw/models/item/sword_great_axeblade.json
+++ b/src/main/resources/assets/mcdw/models/item/sword_great_axeblade.json
@@ -1,35 +1,9 @@
 {
-	"parent": "mcdw:item/model_broadsword",
+	"parent": "mcdw:item/model_claymore",
 	"textures": {
 		"layer0": "mcdw:item/sword_great_axeblade"
 	},
-	"gui_light": "front",
 	"display": {
-		"thirdperson_righthand": {
-			"rotation": [0, -90, 55],
-			"translation": [0, 8.25, 0.5],
-			"scale": [1.7, 1.7, 0.85]
-		},
-		"thirdperson_lefthand": {
-			"rotation": [0, 90, -55],
-			"translation": [0, 8.5, 0.5],
-			"scale": [1.7, 1.7, 0.85]
-		},
-		"firstperson_righthand": {
-			"rotation": [0, -90, 25],
-			"translation": [1.13, 4.2, 1.13],
-			"scale": [1.36, 1.36, 0.68]
-		},
-		"firstperson_lefthand": {
-			"rotation": [0, 90, -25],
-			"translation": [1.13, 4.2, 1.13],
-			"scale": [1.36, 1.36, 0.68]
-		},
-		"fixed": {
-			"rotation": [0, 180, 0],
-			"translation": [0, 0, -0.25],
-			"scale": [2, 2, 1]
-		},  
 		"head": {
 			"rotation": [ 0, 0, 0 ],
 			"translation": [ 0, 2, 0],
@@ -38,6 +12,26 @@
 		"ground": {
 			"translation": [ 0, 2, 0 ],
 			"scale": [ 0.75, 0.75, 0.5 ]
+		},
+		"thirdperson_righthand": {
+			"rotation": [ 0, -90, 55 ],
+			"translation": [ 0, 8.5, 0 ],
+			"scale": [ 2, 2, 0.85 ]
+		},
+		"thirdperson_lefthand": {
+			"rotation": [ 0, 90, -55 ],
+			"translation": [ 0, 8.5, 0 ],
+			"scale": [ 2, 2, 0.85 ]
+		},
+		"firstperson_righthand": {
+			"rotation": [ 0, -90, 25 ],
+			"translation": [ 1.13, 6.2, 1.13 ],
+			"scale": [ 1.5, 1.5, 0.68 ]
+		},
+		"firstperson_lefthand": {
+			"rotation": [ 0, 90, -25 ],
+			"translation": [ 1.13, 6.2, 1.13 ],
+			"scale": [ 1.5, 1.5, 0.68 ]
 		}
 	}
 }

--- a/src/main/resources/assets/mcdw/models/item/sword_hawkbrand.json
+++ b/src/main/resources/assets/mcdw/models/item/sword_hawkbrand.json
@@ -1,5 +1,5 @@
 {
-  "parent": "mcdw:item/model_sword",
+  "parent": "mcdw:item/model_claymore",
   "textures": {
 	  "layer0": "mcdw:item/sword_hawkbrand"
   },  


### PR DESCRIPTION
Improves the scale of claymore type items, so now the size of a render pixel is the same as a pixel in a wooden sword.
Weapons affected:
- Claymore
- Heartstealer
- Frost Slayer
- Hawkbrand
- Great Axeblade

For Hawkbrand and Great Axeblade I modified the parenting for more consistant translation. The result is a more consistent hilt grip position.