### PR TITLE
Made items with InnateEnchantments be enchantable in the enchanting table

### DIFF
--- a/src/main/java/chronosacaria/mcdw/api/interfaces/IInnateEnchantment.java
+++ b/src/main/java/chronosacaria/mcdw/api/interfaces/IInnateEnchantment.java
@@ -2,7 +2,7 @@ package chronosacaria.mcdw.api.interfaces;
 
 import chronosacaria.mcdw.Mcdw;
 import chronosacaria.mcdw.enums.SettingsID;
-import net.minecraft.enchantment.Enchantment;
+import net.minecraft.enchantment.*;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import org.jetbrains.annotations.NotNull;
@@ -41,4 +41,30 @@ public interface IInnateEnchantment {
         }
         return itemStack;
     }
+    
+    /**
+     * Checks a stack if it only has enchantments that are lower or equal its InnateEnchantments,
+     * meaning enchantments had been added on top of the innate ones.
+     *
+     * Copyright 2023 DaFuqs
+     * <br/><br/>
+     * Used with Permission, modifications made to allow for checking whether innate enchantments are enabled or not.
+     * <br/><br/>
+     * The following code is from Spectrum and can be found here:<br/>
+     * <a href = "https://github.com/DaFuqs/Spectrum/blob/1.19-deeper-down/src/main/java/de/dafuqs/spectrum/items/Preenchanted.java#L13">Preenchanted#onlyHasPreEnchantments</a>
+     */
+    default boolean onlyHasInnateEnchantments(ItemStack stack) {
+        Map<Enchantment, Integer> innateEnchantments = getInnateEnchantments();
+        Map<Enchantment, Integer> stackEnchantments = EnchantmentHelper.get(stack);
+        
+        for(Map.Entry<Enchantment, Integer> stackEnchantment : stackEnchantments.entrySet()) {
+            int innateLevel = innateEnchantments.getOrDefault(stackEnchantment.getKey(), 0);
+            if(stackEnchantment.getValue() > innateLevel) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
+    
 }


### PR DESCRIPTION
Added a new method `onlyHasInnateEnchantments()` that returns if a stack only has the enchants (or lesser) that it has, by it InnateEnchantment definition, or other enchants have been added by other means.

The mixin in `ItemStack` allows the Enchanting Table (and other mods) to recognise see the stack as enchantable, even if it has its innate enchantments. Normally that method would always return false, if a stack already had enchantments.