### PR TITLE
remake refreshment enchantment

### DIFF
--- a/src/main/java/chronosacaria/mcdw/effects/EnchantmentEffects.java
+++ b/src/main/java/chronosacaria/mcdw/effects/EnchantmentEffects.java
@@ -31,7 +31,6 @@ import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.projectile.PersistentProjectileEntity;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.Items;
-import net.minecraft.potion.PotionUtil;
 import net.minecraft.potion.Potions;
 import net.minecraft.server.world.ServerWorld;
 import net.minecraft.sound.SoundCategory;
@@ -647,8 +646,7 @@ public class EnchantmentEffects {
         int refreshmentLevel = mcdw$getEnchantmentLevel(EnchantsRegistry.REFRESHMENT, refreshingEntity, isOffHandStack);
 
         if (refreshmentLevel > 0) {
-            ItemStack healthPotion = PotionUtil.setPotion(new ItemStack(Items.POTION), Potions.HEALING);
-            InventoryHelper.mcdw$systematicReplacePotions(refreshingEntity, Items.GLASS_BOTTLE, healthPotion, refreshmentLevel);
+            InventoryHelper.mcdw$systematicReplacePotions(refreshingEntity, Items.GLASS_BOTTLE, Potions.HEALING, refreshmentLevel);
         }
     }
 


### PR DESCRIPTION
This PR remakes implementation of refreshment enchantment to make it properly work with enchantment levels more than 1 and to make filling mechanic more similar to how vanilla bottles work when you fill them with water.
### This is how it worked before:
Preparation (the sword is with Refreshment III)
![before1](https://github.com/chronosacaria/MCDungeonsWeapons/assets/60041069/390a2a3e-b64b-4895-b9b9-02163e18cdbc)
After the kill (bottles "jump" to other slots, which is weird)
![before2](https://github.com/chronosacaria/MCDungeonsWeapons/assets/60041069/6dc8bd98-2ef1-41a8-8ee7-72ea7bafa6f1)
After player drinks the bottle (other two just disappear)
![before3](https://github.com/chronosacaria/MCDungeonsWeapons/assets/60041069/f95c80f4-6a71-4a56-be07-8b2755937e6e)
### This is how it works now:
Preparation
![after1](https://github.com/chronosacaria/MCDungeonsWeapons/assets/60041069/679aa3a1-9494-4fcc-8d77-96a956fa8d0b)
After the kill (bottles are filled in-place)
![after2](https://github.com/chronosacaria/MCDungeonsWeapons/assets/60041069/52d98c2f-4e1f-4e1a-b2cf-726d4df71bb9)
After player drinks the bottle
![after3](https://github.com/chronosacaria/MCDungeonsWeapons/assets/60041069/915fbc40-854d-400b-a858-ea2a0db1e200)
