### PR TITLE
Updated to 1.20.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id 'fabric-loom' version '1.2-SNAPSHOT'
+    id 'fabric-loom' version '1.6-SNAPSHOT'
     id 'maven-publish'
 }
 
@@ -53,7 +53,7 @@ dependencies {
     modImplementation "com.blamejared.clumps:Clumps-fabric-${project.minecraft_version}:${project.clumps_version}"
 
     // Projectile Damage
-    modImplementation "maven.modrinth:projectile-damage-attribute:${project.projectile_damage_version}+${project.minecraft_version}-fabric"
+    modImplementation "maven.modrinth:projectile-damage-attribute:${project.projectile_damage_version}+1.20-fabric"
 
     // Cloth Config
     modApi("me.shedaniel.cloth:cloth-config-fabric:${project.cloth_config_version}") {
@@ -62,15 +62,6 @@ dependencies {
 
     // Reach Entity Attributes
     modImplementation "com.jamieswhiteshirt:reach-entity-attributes:${project.reach_entity_attributes_version}"
-
-    // Pehkui
-    //modApi("com.github.Virtuoel:Pehkui:${project.pehkui_version}", {
-    //    exclude group: "net.fabricmc.fabric-api"
-    //})
-
-    // Mixin Extras
-    include(implementation(annotationProcessor("com.github.llamalad7.mixinextras:mixinextras-fabric:${project.mixin_extras_version}")))
-
 }
 
 processResources {

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,9 +3,9 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
     # check these on https://fabricmc.net/develop/
-    minecraft_version=1.20
-    yarn_mappings=1.20+build.1
-    loader_version=0.14.21
+minecraft_version=1.20.4
+yarn_mappings=1.20.4+build.3
+loader_version=0.15.6
 
 # Mod Properties
     mod_version=9.0.1
@@ -14,12 +14,12 @@ org.gradle.jvmargs=-Xmx1G
 
 # Dependencies
     # check this on https://fabricmc.net/develop/
-    fabric_version=0.83.0+1.20
-    cloth_config_version=11.0.99
-    mixin_extras_version=0.2.0-beta.8
+fabric_version=0.95.4+1.20.4
+cloth_config_version=13.0.121
+mixin_extras_version=0.3.5
 
 # Compatibility
-    clumps_version=11.0.0.1
+    clumps_version=15.0.0.2
     projectile_damage_version=3.2.1
     reach_entity_attributes_version=2.4.0
     #pehkui_version=3.7.8

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.1.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/chronosacaria/mcdw/mixin/mcdw/client/InGameHudMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/mcdw/client/InGameHudMixin.java
@@ -39,7 +39,11 @@ public class InGameHudMixin {
     @Shadow
     private int scaledWidth;
 
-    @Shadow @Final private static Identifier ICONS;
+    @Shadow @Final private static Identifier CROSSHAIR_ATTACK_INDICATOR_BACKGROUND_TEXTURE;
+
+    @Shadow @Final private static Identifier CROSSHAIR_ATTACK_INDICATOR_FULL_TEXTURE;
+
+    @Shadow @Final private static Identifier CROSSHAIR_ATTACK_INDICATOR_PROGRESS_TEXTURE;
 
     public InGameHudMixin(MinecraftClient client) {
         this.client = client;
@@ -69,11 +73,11 @@ public class InGameHudMixin {
                                 int height = this.scaledHeight / 2 - 7 + 16;
                                 int width = this.scaledWidth / 2 - 8;
                                 if (bl) {
-                                    context.drawTexture(ICONS, width, height + 8, 68, 94, 16, 16, 256, 256);
-                                } else if (offhandAttackCooldownProgress < 1.0f) {
-                                    int l = (int) (offhandAttackCooldownProgress * 17.0f);
-                                    context.drawTexture(ICONS, width, height + 8, 36, 94, 16, 4, 256, 256);
-                                    context.drawTexture(ICONS, width, height + 8, 52, 94, l, 4, 256, 256);
+                                    context.drawGuiTexture(CROSSHAIR_ATTACK_INDICATOR_FULL_TEXTURE, width, height+8, 16, 16);
+                                } else if (offhandAttackCooldownProgress < 1.0F) {
+                                    int l = (int)(offhandAttackCooldownProgress * 17.0F);
+                                    context.drawGuiTexture(CROSSHAIR_ATTACK_INDICATOR_BACKGROUND_TEXTURE, width, height+8, 16, 4);
+                                    context.drawGuiTexture(CROSSHAIR_ATTACK_INDICATOR_PROGRESS_TEXTURE, 16, 4, 0, 0, width, height +8 , l, 4);
                                 }
                             }
                         }

--- a/src/main/java/chronosacaria/mcdw/mixin/reach/client/GameRendererMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/reach/client/GameRendererMixin.java
@@ -39,16 +39,8 @@ public abstract class GameRendererMixin implements SynchronousResourceReloader {
         return reachDistance;
     }
 
-    @ModifyConstant(method = "updateTargetedEntity", require = 1, allow = 1, constant = @Constant(doubleValue = 3.0))
-    private double mcdw$updateTargetedEntityII(double attackRange) {
-        if (MinecraftClient.getInstance().player != null) {
-            return PlayerAttackHelper.mcdw$getAttackRange(MinecraftClient.getInstance().player, attackRange);
-        }
-        return attackRange;
-    }
-
     @ModifyConstant(method = "updateTargetedEntity", require = 1, allow = 1, constant = @Constant(doubleValue = 9.0))
-    private double mcdw$updateTargetedEntityIII(double attackRange) {
+    private double mcdw$updateTargetedEntityII(double attackRange) {
         if (MinecraftClient.getInstance().player != null) {
             return PlayerAttackHelper.mcdw$getSquaredAttackRange(MinecraftClient.getInstance().player, attackRange);
         }

--- a/src/main/java/chronosacaria/mcdw/mixin/reach/client/PlayerEntityMixin.java
+++ b/src/main/java/chronosacaria/mcdw/mixin/reach/client/PlayerEntityMixin.java
@@ -3,6 +3,7 @@ package chronosacaria.mcdw.mixin.reach.client;
 import chronosacaria.mcdw.api.util.PlayerAttackHelper;
 import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.entity.player.PlayerEntity;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.Constant;
 import org.spongepowered.asm.mixin.injection.ModifyConstant;
@@ -28,11 +29,11 @@ import org.spongepowered.asm.mixin.injection.ModifyConstant;
  * <a href = "https://github.com/JamiesWhiteShirt/reach-entity-attributes/blob/1.19/src/main/java/com/jamieswhiteshirt/reachentityattributes/mixin/client/ClientPlayerInteractionManagerMixin.java">ClientPlayerInteractionManagerMixin</a>
  */
 
-@Mixin(ClientPlayerInteractionManager.class)
-public class ClientPlayerInteractionManagerMixin {
+@Mixin(PlayerEntity.class)
+public class PlayerEntityMixin {
     @ModifyConstant(method = "getReachDistance", require = 2, allow = 2,
     constant = { @Constant(floatValue = 5.0F), @Constant(floatValue = 4.5F)})
-    private float mcdw$getReachDistance(float reachDistance) {
+    private static float mcdw$getReachDistance(float reachDistance) {
         if (MinecraftClient.getInstance().player != null) {
             return (float) PlayerAttackHelper.mcdw$getReachDistance(MinecraftClient.getInstance().player, reachDistance);
         }

--- a/src/main/java/chronosacaria/mcdw/networking/OffhandAttackPacket.java
+++ b/src/main/java/chronosacaria/mcdw/networking/OffhandAttackPacket.java
@@ -8,6 +8,7 @@ import net.fabricmc.fabric.api.client.networking.v1.ClientPlayNetworking;
 import net.fabricmc.fabric.api.networking.v1.ServerPlayNetworking;
 import net.minecraft.entity.Entity;
 import net.minecraft.network.PacketByteBuf;
+import net.minecraft.network.listener.ServerCommonPacketListener;
 import net.minecraft.network.listener.ServerPlayPacketListener;
 import net.minecraft.network.packet.Packet;
 import net.minecraft.server.world.ServerWorld;
@@ -19,7 +20,7 @@ public class OffhandAttackPacket {
     public static final Identifier OFFHAND_ATTACK_PACKET = new Identifier(Mcdw.MOD_ID, "offhand_attack_entity");
     public static final Identifier OFFHAND_MISS_PACKET = new Identifier(Mcdw.MOD_ID, "offhand_miss_entity");
 
-    public static Packet<ServerPlayPacketListener> offhandAttackPacket(Entity entity) {
+    public static Packet<ServerCommonPacketListener> offhandAttackPacket(Entity entity) {
         PacketByteBuf buf = new PacketByteBuf(Unpooled.buffer());
         buf.writeInt(entity.getId());
         return ClientPlayNetworking.createC2SPacket(OFFHAND_ATTACK_PACKET, buf);

--- a/src/main/java/chronosacaria/mcdw/registries/LootTablesRegistry.java
+++ b/src/main/java/chronosacaria/mcdw/registries/LootTablesRegistry.java
@@ -107,7 +107,7 @@ public class LootTablesRegistry {
                     EPIC_LOOT_POOL.forEach(lootID -> addWeaponById(lootPoolBuilder, lootID));
 
                 if (NETHER_TABLES.contains(id.toString())) {
-                    if (Arrays.stream(lootPoolBuilder.build().entries).noneMatch(lootPoolEntry ->
+                    if (lootPoolBuilder.build().entries.stream().noneMatch(lootPoolEntry ->
                             lootPoolEntry.equals(ItemEntry.builder(CrossbowsID.CROSSBOW_PRIDE_OF_THE_PIGLINS.getItem())
                                     .weight(CrossbowsID.CROSSBOW_PRIDE_OF_THE_PIGLINS.getItemSpawnRate()).build()))) {
                         addWeaponById(lootPoolBuilder, CrossbowsID.CROSSBOW_PRIDE_OF_THE_PIGLINS);

--- a/src/main/java/chronosacaria/mcdw/statuseffects/ShadowFormStatusEffect.java
+++ b/src/main/java/chronosacaria/mcdw/statuseffects/ShadowFormStatusEffect.java
@@ -23,8 +23,8 @@ public class ShadowFormStatusEffect extends StatusEffect {
     }
 
     @Override
-    public void onApplied(LivingEntity entity, AttributeContainer attributes, int amplifier){
-        super.onApplied(entity, attributes, amplifier);
+    public void onApplied(LivingEntity entity, int amplifier){
+        super.onApplied(entity, amplifier);
         entity.addStatusEffect(new StatusEffectInstance(StatusEffects.INVISIBILITY, 80, amplifier,false,false,false));
     }
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -49,7 +49,7 @@
   "depends": {
     "fabricloader": ">=0.14.21",
     "fabric": "*",
-    "minecraft": ">=1.20.0 <=1.20.1",
+    "minecraft": ">=1.20.3",
     "cloth-config2": ">=11.0.0.1"
   }
 }

--- a/src/main/resources/mcdw.mixins.json
+++ b/src/main/resources/mcdw.mixins.json
@@ -35,7 +35,7 @@
     "mcdw.client.InGameHudMixin",
     "mcdw.client.ModelPredicateProviderRegistryMixin",
     "mcdw.client.PlayerEntityRendererMixin",
-    "reach.client.ClientPlayerInteractionManagerMixin",
+    "reach.client.PlayerEntityMixin",
     "reach.client.GameRendererMixin"
   ],
   "injectors": {


### PR DESCRIPTION
Updated MCDungeonWeapons to Minecraft 1.20.4. 
Testing suggests that the port works as intended. 
Running this port requires an, at the time this pull requested is being opened, unofficial 1.20.4 build of Better Combat: https://github.com/ZsoltMolnarrr/BetterCombat/pull/332