### PR TITLE
Fix total config collapse on improper update

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx1G
     loader_version=0.14.21
 
 # Mod Properties
-    mod_version=9.0.2
+    mod_version=9.0.3
     maven_group=chronosacaria
     archives_base_name=mcdw
 

--- a/src/main/java/chronosacaria/mcdw/enums/IMeleeWeaponID.java
+++ b/src/main/java/chronosacaria/mcdw/enums/IMeleeWeaponID.java
@@ -25,11 +25,11 @@ public interface IMeleeWeaponID extends IMcdwWeaponID {
     MeleeStats getMeleeStats();
 
     class MeleeStats {
-        boolean isEnabled;
-        String material;
-        int damage;
-        float attackSpeed;
-        String[] repairIngredient;
+        boolean isEnabled = true;
+        String material = "iron";
+        int damage = 0;
+        float attackSpeed = -3f;
+        String[] repairIngredient = new String[]{};
 
         public MeleeStats meleeStats(boolean isEnabled, String material, int damage, float attackSpeed, String[] repairIngredient) {
             this.isEnabled = isEnabled;

--- a/src/main/java/chronosacaria/mcdw/enums/IRangedWeaponID.java
+++ b/src/main/java/chronosacaria/mcdw/enums/IRangedWeaponID.java
@@ -29,12 +29,12 @@ public interface IRangedWeaponID extends IMcdwWeaponID {
     RangedStats getRangedStats();
 
     class RangedStats {
-        public boolean isEnabled;
-        public String material;
-        public double projectileDamage;
-        public int drawSpeed;
-        public float range;
-        String[] repairIngredient;
+        public boolean isEnabled = true;
+        public String material = "iron";
+        public double projectileDamage = 0.0;
+        public int drawSpeed = 20;
+        public float range = 16f;
+        String[] repairIngredient = new String[]{};
 
         public RangedStats rangedStats(boolean isEnabled, String material, double projectileDamage, int drawSpeed, float range, String[] repairIngredient) {
             this.isEnabled = isEnabled;

--- a/src/main/java/chronosacaria/mcdw/enums/IShieldID.java
+++ b/src/main/java/chronosacaria/mcdw/enums/IShieldID.java
@@ -27,9 +27,9 @@ public interface IShieldID extends IMcdwWeaponID {
     ShieldStats getShieldStats();
 
     class ShieldStats {
-        boolean isEnabled;
-        String material;
-        String[] repairIngredient;
+        boolean isEnabled = true;
+        String material = "diamond";
+        String[] repairIngredient = new String[]{};
 
         public ShieldStats shieldStats(boolean isEnabled, String material, String[] repairIngredient) {
             this.isEnabled = isEnabled;


### PR DESCRIPTION
Resolves the numerous issues here and in the discord of the update causing all MCDW weapons to vanish. 

Accomplishes this by adding "dummy" values to the various "____Stats" classes. Doing this seems to appease Jankson, and allows for the config generation to actually go through.

Behavior 9.0.1 -> 9.0.2: If configs aren't updated, all weapons fail to register (because they are "disabled"), all weapons in players inventories vanish permanently.
Behavior 9.0.1 -> 9.0.3: Config updates with the `isEnabled` flags, registry is maintained, and items stay intact.